### PR TITLE
Feat/timer completion modal:Timer Completion Modal & Cumulative Status Sync

### DIFF
--- a/src/components/modal/TimerCompletionModal.tsx
+++ b/src/components/modal/TimerCompletionModal.tsx
@@ -1,0 +1,42 @@
+import { DialogDescription } from '@radix-ui/react-dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+
+interface TimerCompletionModalProps {
+  open: boolean;
+  onConfirm: () => void;
+  totalFocusTime: string;
+}
+
+export default function TimerCompletionModal({
+  open,
+  onConfirm,
+  totalFocusTime,
+}: TimerCompletionModalProps) {
+  return (
+    <Dialog open={open}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-2xl font-bold text-center">
+            Focus Complete!⭐️
+          </DialogTitle>
+          <DialogDescription className="text-center pt-4 text-lg">
+            You’ve completed **{totalFocusTime}** of deep work. Ready to save
+            and head back?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex justify-center sm:justify-center gap-2 pt-4">
+          <Button className="w-full" variant="default" onClick={onConfirm}>
+            Save & Exit
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -200,7 +200,9 @@ export default function FocusPage() {
       <TimerCompletionModal
         open={isCompletionModalOpen}
         onConfirm={handleConfirmCompletion}
-        totalFocusTime={formatTime(initialTime).fullTimeDisplay}
+        totalFocusTime={
+          formatTime(currentTodo.totalFocusTime + initialTime).fullTimeDisplay
+        }
       />
     </div>
   );

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -1,8 +1,9 @@
 import { FocusStopModal } from '@/components/modal/FocusStopModal';
+import TimerCompletionModal from '@/components/modal/TimerCompletionModal';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { formatTime } from '@/lib/utils';
-import { useAddFocusTime, useTodo } from '@/stores/useTodoStore';
+import { useAddFocusTime, useTodo, useUpdateTodo } from '@/stores/useTodoStore';
 import { Play, Square, MoveLeft, Pause } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -17,12 +18,14 @@ export default function FocusPage() {
   const todos = useTodo();
   const currentTodo = todos.find((t) => t.id === todoId);
   const addFocusTime = useAddFocusTime();
+  const updateTodoStatus = useUpdateTodo();
 
   const [status, setStatus] = useState<TimerStatus>('idle');
   const [timeLeft, setTimeLeft] = useState(1500);
   const [initialTime, setInitialTime] = useState(1500);
 
   const [isStopModalOpen, setIsStopModalOpen] = useState(false);
+  const [isCompletionModalOpen, setIsCompletionModalOpen] = useState(false);
   const [isCustomInputOpen, setIsCustomInputOpen] = useState(false);
   const [customMinutes, setCustomMinutes] = useState('');
 
@@ -47,31 +50,47 @@ export default function FocusPage() {
   const handleStopClick = () => setIsStopModalOpen(true);
 
   const handleConfirmStop = () => {
-    handleTimerComplete();
-    setStatus('idle');
-    setTimeLeft(initialTime);
+    saveFocusedTime();
     setIsStopModalOpen(false);
+    navigate('/');
+  };
+
+  const handleConfirmCompletion = () => {
+    saveFocusedTime();
+    setIsCompletionModalOpen(false);
     navigate('/');
   };
 
   useInterval(
     () => {
       if (timeLeft > 0) {
-        setTimeLeft((prev) => prev - 1);
-      } else {
-        setStatus('completed');
-        handleTimerComplete();
+        const nextTime = timeLeft - 1;
+        setTimeLeft(nextTime);
+
+        if (nextTime === 0) {
+          setStatus('completed');
+          setIsCompletionModalOpen(true);
+        }
       }
     },
-    status === 'running' && !isStopModalOpen ? 1000 : null,
+
+    status === 'running' && !isStopModalOpen && !isCompletionModalOpen
+      ? 1000
+      : null,
   );
 
-  const handleTimerComplete = () => {
-    if (!todoId) return;
+  const saveFocusedTime = () => {
+    if (!todoId || !currentTodo) return;
 
     const focusedSeconds = initialTime - timeLeft;
-    if (todoId && currentTodo) {
+
+    if (focusedSeconds > 0) {
       addFocusTime(todoId, focusedSeconds);
+      setTimeLeft(initialTime);
+
+      if (timeLeft === 0 && currentTodo.status !== 'completed') {
+        updateTodoStatus(todoId, { status: 'completed' });
+      }
     }
   };
 
@@ -171,6 +190,18 @@ export default function FocusPage() {
           <div>{formatTime(currentTodo.totalFocusTime).fullTimeDisplay}</div>
         </div>
       </footer>
+
+      <FocusStopModal
+        open={isStopModalOpen}
+        onOpenChange={setIsStopModalOpen}
+        onConfirm={handleConfirmStop}
+      />
+
+      <TimerCompletionModal
+        open={isCompletionModalOpen}
+        onConfirm={handleConfirmCompletion}
+        totalFocusTime={formatTime(initialTime).fullTimeDisplay}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 📌 Description
Successfully implemented a robust timer completion flow and data synchronization logic. This update ensures that focus time is accurately recorded without duplication. It also provides an enhanced UX by displaying the **cumulative total focus time** in a new completion modal and automatically updating the task status upon finishing.

## 🛠️ Key Changes
- **Timer Completion Modal**: Introduced a "Task Complete" modal that triggers at the end of a session, showing the total accumulated focus time (previous + current).
- **Strict Timer Logic**: Refactored `useInterval` to trigger exactly at `00:00:00` without the 1-second delay bug.
- **Data Integrity & Bug Fix**: Centralized the saving process in `saveFocusedTime` to resolve the "double-saving" issue (e.g., 1 min saving as 2 mins).
- **Zustand Auto-Sync**: Integrated `updateTodo` to automatically transition task status from `'active'` to `'completed'` when the timer reaches zero.

## 🧠 Design Notes
- **Cumulative Calculation**: The modal displays `currentTodo.totalFocusTime + initialTime` to provide users with a sense of total achievement for the specific task.
- **Atomic State Guard**: Used a `nextTime` constant within the interval to ensure state updates and modal triggers happen synchronously and only once.

## 📸 Screenshots
<img width="705" height="545" alt="1" src="https://github.com/user-attachments/assets/9f8561c0-1482-48c9-a4b8-bb050b0a5f6c" />
<img width="764" height="472" alt="2" src="https://github.com/user-attachments/assets/6b4851f7-e00a-4241-9445-c684155ac9c6" />

## ✅ Checklist
- [x] Verified total cumulative time is displayed correctly in the modal. 
- [x] Confirmed `useInterval` stops immediately and triggers modal at 0s.
- [x] Validated `updateTodo` correctly updates status to 'completed' in Zustand.
- [x] Tested both "Stop" (partial save) and "Auto-Complete" (full save) flows.
