### PR TITLE
Refactor/focus page logic:Refactor Focus Page and Enhance Custom Time Settings UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,11 @@
         "d3": "^7.9.0",
         "dayjs": "^1.11.19",
         "lucide-react": "^0.562.0",
+        "next-themes": "^0.4.6",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-router": "^7.12.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "usehooks-ts": "^3.1.1",
         "zustand": "^5.0.10"
@@ -4818,6 +4820,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -5230,6 +5242,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "d3": "^7.9.0",
     "dayjs": "^1.11.19",
     "lucide-react": "^0.562.0",
+    "next-themes": "^0.4.6",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-router": "^7.12.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "usehooks-ts": "^3.1.1",
     "zustand": "^5.0.10"

--- a/src/components/modal/CustomDurationModal.tsx
+++ b/src/components/modal/CustomDurationModal.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogFooter,
+  DialogHeader,
+  DialogContent,
+  DialogTitle,
+} from '../ui/dialog';
+import { Input } from '../ui/input';
+import { Button } from '../ui/button';
+
+interface CustomDurationModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSetDuration: (minutes: number) => void;
+}
+
+export default function CustomDurationModal({
+  open,
+  onOpenChange,
+  onSetDuration,
+}: CustomDurationModalProps) {
+  const [value, setValue] = useState('');
+
+  const handleConfirm = () => {
+    const mins = Number(value);
+    if (isNaN(mins) || mins <= 0 || mins > 1440) {
+      toast.error('Invalid Input', {
+        description: 'Please enter a time between 1 and 1440 minutes.',
+      });
+      return;
+    }
+
+    onSetDuration(mins);
+    toast.success(`Timer set to ${mins} minutes!`);
+    onOpenChange(false);
+    setValue('');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Set Custom Focus Time</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="flex flex-col gap-2">
+            <label htmlFor="minutes" className="text-sm font-medium">
+              Minutes
+            </label>
+            <Input
+              id="minutes"
+              type="number"
+              placeholder="e.g. 25"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleConfirm()}
+              autoFocus
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm}>Set Time</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,38 @@
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { useInterval } from 'usehooks-ts';
+
+export type TimerStatus = 'idle' | 'running' | 'paused' | 'completed';
+
+interface UseTimerProps {
+  initialSeconds: number;
+  onComplete: () => void;
+}
+
+export const useTimer = ({ initialSeconds, onComplete }: UseTimerProps) => {
+  const [status, setStatus] = useState<TimerStatus>('idle');
+  const [timeLeft, setTimeLeft] = useState(initialSeconds);
+  const [currentInitialTime, setCurrentInitialTime] = useState(initialSeconds);
+
+  const setDuration = (minutes: number) => {
+    const seconds = minutes * 60;
+    setStatus('idle');
+    setTimeLeft(seconds);
+    setCurrentInitialTime(seconds);
+  };
+
+  const togglePlay = () => {
+    setStatus((prev) => (prev === 'running' ? 'paused' : 'running'));
+  };
+
+  const stop = () => setStatus('paused');
+
+  useInterval(
+    () => {
+      if (timeLeft > 0) {
+        const nextTime = timeLeft - 1;
+        setTimeLeft(nextTime);
+
+        if (nextTime === 0) {
+          setStatus('completed');
+          onComplete();
+        }
+      }
+    },
+    status === 'running' ? 1000 : null,
+  );
+
+  return {
+    status,
+    timeLeft,
+    initialTime: currentInitialTime,
+    setDuration,
+    togglePlay,
+    stop,
+    setTimeLeft,
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import NotFound from './pages/NotFound.tsx';
 import TodayPage from './pages/TodayPage.tsx';
 import FocusPage from './pages/FocusPage.tsx';
 import FocusHistoryPage from './pages/FocusHistoryPage.tsx';
+import { Toaster } from './components/ui/sonner.tsx';
 
 const router = createBrowserRouter([
   {
@@ -25,6 +26,7 @@ const router = createBrowserRouter([
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
+    <Toaster richColors position="top-center" />
     <RouterProvider router={router} />
   </StrictMode>,
 );

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -1,7 +1,7 @@
+import CustomDurationModal from '@/components/modal/CustomDurationModal';
 import { FocusStopModal } from '@/components/modal/FocusStopModal';
 import TimerCompletionModal from '@/components/modal/TimerCompletionModal';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { useTimer } from '@/hooks/useTimer';
 import { formatTime } from '@/lib/utils';
 import { useAddFocusTime, useTodo, useUpdateTodo } from '@/stores/useTodoStore';
@@ -21,8 +21,7 @@ export default function FocusPage() {
   const [isStopModalOpen, setIsStopModalOpen] = useState(false);
   const [isCompletionModalOpen, setIsCompletionModalOpen] = useState(false);
 
-  const [isCustomInputOpen, setIsCustomInputOpen] = useState(false);
-  const [customMinutes, setCustomMinutes] = useState('');
+  const [isCustomModalOpen, setIsCustomModalOpen] = useState(false);
 
   const { status, timeLeft, initialTime, setDuration, togglePlay, stop } =
     useTimer({
@@ -86,7 +85,7 @@ export default function FocusPage() {
             variant={initialTime === 1500 ? 'default' : 'outline'}
             onClick={() => {
               setDuration(25);
-              setIsCustomInputOpen(false);
+              setIsCustomModalOpen(false);
             }}
           >
             00:25
@@ -95,39 +94,19 @@ export default function FocusPage() {
             variant={initialTime === 3000 ? 'default' : 'outline'}
             onClick={() => {
               setDuration(50);
-              setIsCustomInputOpen(false);
+              setIsCustomModalOpen(false);
             }}
           >
             00:50
           </Button>
           <Button
             variant={'outline'}
-            onClick={() => setIsCustomInputOpen(!isCustomInputOpen)}
+            onClick={() => setIsCustomModalOpen(true)}
           >
             Custom
           </Button>
-
-          {isCustomInputOpen && (
-            <div className="flex gap-2 items-center animate-in fade-in zoom-in duration-200">
-              <Input
-                className="w-24"
-                type="number"
-                placeholder="Minutes"
-                value={customMinutes}
-                onChange={(e) => setCustomMinutes(e.target.value)}
-              />
-              <Button
-                size={'sm'}
-                onClick={() => {
-                  setDuration(Number(customMinutes));
-                  setIsCustomInputOpen(false);
-                }}
-              >
-                Set
-              </Button>
-            </div>
-          )}
         </div>
+
         <div className="flex gap-6 items-center">
           <Button className="rounded-full w-15 h-15" onClick={togglePlay}>
             {status === 'running' ? <Pause /> : <Play />}
@@ -151,6 +130,12 @@ export default function FocusPage() {
           <div>{formatTime(currentTodo.totalFocusTime).fullTimeDisplay}</div>
         </div>
       </footer>
+
+      <CustomDurationModal
+        open={isCustomModalOpen}
+        onOpenChange={setIsCustomModalOpen}
+        onSetDuration={(mins) => setDuration(mins)}
+      />
 
       <FocusStopModal
         open={isStopModalOpen}

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -83,19 +83,13 @@ export default function FocusPage() {
         <div className="flex gap-3 p-2">
           <Button
             variant={initialTime === 1500 ? 'default' : 'outline'}
-            onClick={() => {
-              setDuration(25);
-              setIsCustomModalOpen(false);
-            }}
+            onClick={() => setDuration(25)}
           >
             00:25
           </Button>
           <Button
             variant={initialTime === 3000 ? 'default' : 'outline'}
-            onClick={() => {
-              setDuration(50);
-              setIsCustomModalOpen(false);
-            }}
+            onClick={() => setDuration(50)}
           >
             00:50
           </Button>


### PR DESCRIPTION
## 📌 Description
This PR focuses on improving the architectural stability of the focus timer and enhancing the user experience by transitioning from inline inputs to a structured modal-driven approach. It also separates core business logic from the UI components for better maintainability and global scalability.

## 🛠️ Key Changes
### 1. Logic Decoupling
* Extracted timer interval and state management into a custom `useTimer` hook.

### 2. Component Implementation & Refactoring
* **Added `CustomDurationModal`**: Integrated a new modal component for flexible time settings.
* **Prop Refactoring**: Updated `FocusPage` to pass state-control props (`open`, `onOpenChange`, `onSetDuration`) to the new modal, ensuring synchronized state management. ⭐️
* **Code Optimization**: Removed redundant `setIsCustomModalOpen(false)` logic from preset duration buttons (25m/50m) to simplify event handlers and clean up the state flow.

### 3. UI/UX Improvement
* Replaced standard browser alerts with `sonner` toast notifications for a modern feel.
* Centralized `Toaster` in `main.tsx` to support notifications on independent routes like `/focus`.

### 4. Bug Fixes
* Resolved an issue where the custom modal rendered as a plain inline element due to incorrect library import paths and CSS class spacing.

## 🧠 Design Notes
- **Consistency**: Synchronized data units between the custom modal (minutes) and the timer engine (seconds) to maintain data integrity.
- **Refinement**: Cleaned up unnecessary state calls in the `FocusPage` to improve maintainability.

## 📸ScreenShots
<img width="752" height="616" alt="1" src="https://github.com/user-attachments/assets/481ceae7-b13e-44ac-8b5f-5abc939010f1" />
<img width="709" height="581" alt="2" src="https://github.com/user-attachments/assets/6167a6bc-398a-4d13-99f1-a8e26d7887e5" />
<img width="628" height="492" alt="3" src="https://github.com/user-attachments/assets/2ad786f1-f860-4b52-9054-fa2e90e1a52a" />


## ✅ Checklist
- [x] Types verified
- [x] Local run checked
- [x] Sonner toast visibility confirmed on `/focus` route
- [x] Custom modal layout and centering fixed
- [x] Input validation for custom duration (1-1440 mins) verified
