### PR TITLE
feat(FocusPage): [UX/Refactor] Improve Timer Auto-Resume and Time Formatting System

### DIFF
--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -25,6 +25,7 @@ export const useTimer = ({ initialSeconds, onComplete }: UseTimerProps) => {
   };
 
   const stop = () => setStatus('paused');
+  const resume = () => setStatus('running');
 
   useInterval(
     () => {
@@ -47,6 +48,7 @@ export const useTimer = ({ initialSeconds, onComplete }: UseTimerProps) => {
     initialTime: currentInitialTime,
     setDuration,
     togglePlay,
+    resume,
     stop,
     setTimeLeft,
   };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -17,7 +17,7 @@ export const formatTime = (totalSeconds: number) => {
   const seconds = s.toString().padStart(2, '0');
 
   const fullTimeDisplay =
-    Number(hours) > 0 ? `${hours}h:${minutes}m` : `${minutes}m:${seconds}s`;
+    Number(hours) > 0 ? `${hours}h ${minutes}m` : `${minutes}m ${seconds}s`;
   return { fullTimeDisplay, hours, minutes, seconds };
 };
 

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -23,13 +23,26 @@ export default function FocusPage() {
 
   const [isCustomModalOpen, setIsCustomModalOpen] = useState(false);
 
-  const { status, timeLeft, initialTime, setDuration, togglePlay, stop } =
-    useTimer({
-      initialSeconds: 1500,
-      onComplete: () => setIsCompletionModalOpen(true),
-    });
+  const {
+    status,
+    timeLeft,
+    initialTime,
+    setDuration,
+    togglePlay,
+    stop,
+    resume,
+  } = useTimer({
+    initialSeconds: 1500,
+    onComplete: () => setIsCompletionModalOpen(true),
+  });
 
   const { hours, minutes, seconds } = formatTime(timeLeft);
+
+  const handleStopModalChange = (open: boolean) => {
+    setIsStopModalOpen(open);
+
+    if (!open) resume();
+  };
 
   const handleStopClick = () => {
     stop();
@@ -69,14 +82,15 @@ export default function FocusPage() {
       <main className="flex flex-col items-center justify-center gap-5 ">
         <div className="flex items-center justify-center text-5xl border-2 rounded-full w-85 h-85 font-mono mt-5 ">
           <div className="flex items-baseline">
-            <span>{hours}</span>
-            <span className="text-sm text-muted-foreground">h</span>
-            <span className="text-muted-foreground">:</span>
+            {Number(hours) > 0 && (
+              <>
+                <span>{hours}</span>
+                <span className="text-muted-foreground">:</span>
+              </>
+            )}
             <span>{minutes}</span>
-            <span className="text-sm text-muted-foreground">m</span>
             <span className="text-muted-foreground">:</span>
             <span>{seconds}</span>
-            <span className="text-sm text-muted-foreground">s</span>
           </div>
         </div>
 
@@ -133,7 +147,7 @@ export default function FocusPage() {
 
       <FocusStopModal
         open={isStopModalOpen}
-        onOpenChange={setIsStopModalOpen}
+        onOpenChange={handleStopModalChange}
         onConfirm={handleSaveAndExit}
       />
 


### PR DESCRIPTION
## 📌 Description
This PR focuses on implementing an **Auto-Resume** logic to maintain the user's focus flow and building an intuitive time formatting system that handles various cases (under/over 1 hour) without ambiguity.

## 🛠️ Key Changes
### 1. Auto-Resume Logic
* **`useTimer` Hook Enhancement**: Added a `resume()` function to explicitly transition the timer state to `running`.
* **`FocusStopModal` Integration**: Improved UX by ensuring the timer resumes immediately when the modal is closed (via 'Keep Going' or clicking outside), eliminating unnecessary extra clicks. 

### 2. Time Display Optimization
* **Main Timer**: Removed `m` and `s` units to focus on the dynamic countdown. Used a colon-separated format for a cleaner look.
* **Total Focus Time**: To prevent confusion with 'Month' (e.g., `01m`), the display now explicitly shows `m` and `s` units for records under 1 hour (e.g., `25m 08s`).
* **Conditional Rendering**: Implemented logic to hide the hours (`h`) unit when the remaining time is less than 60 minutes to reduce visual clutter.

### 3. Utility Refinement
* Structured the `formatTime` utility to return both raw components and a pre-formatted `fullTimeDisplay` string, ensuring consistency across different UI sections.

## 🧠 Design Notes
- Interpreted modal closing as an intent to "Continue Focusing" to minimize journey friction
- Differentiated formats between "Active Timer" and "Static Records" for better data distinction

## 📸ScreenShots
`Befor`
<img width="624" height="702" alt="b1" src="https://github.com/user-attachments/assets/846cb1ed-e006-4908-b9f3-dcc2e510b214" />
<img width="754" height="371" alt="b2" src="https://github.com/user-attachments/assets/1d76fd5f-7f09-4ea2-9beb-6bc440f505ba" />

`After`
<img width="683" height="723" alt="a1" src="https://github.com/user-attachments/assets/a01e409f-4706-4dd3-954a-a046fe96c831" />
<img width="710" height="306" alt="a2" src="https://github.com/user-attachments/assets/51c11d04-38fc-4c79-b6af-113dac93584d" />

## ✅ Checklist
- [x] Types verified
- [x] Local run checked
- [x] Verified timer auto-resumes upon closing the stop modal 
- [x] Verified formatting transitions correctly (Over vs. Under 1 hour)