### PR TITLE
style: normalize layout padding for dashboard and addTodo

### DIFF
--- a/src/features/dashboard/MiniDashboard.tsx
+++ b/src/features/dashboard/MiniDashboard.tsx
@@ -15,11 +15,11 @@ export default function MiniDashboard({
 }: MiniDashboardProps) {
   return (
     <section className="flex justify-between items-center select-none w-full gap-4">
-      <div className="flex-1 border-2 px-6 py-3 rounded-2xl">
+      <div className="flex-1 border-2 px-6 py-4 rounded-2xl">
         <h3 className="text-sm font-semibold text-gray-500">
           Total Focus Time
         </h3>
-        <div className="flex items-center gap-2 pt-4">
+        <div className="flex items-center gap-2 pt-2">
           <Clock4 className="w-5 h-5" />
           <span className="text-xl font-bold">
             {formattedFocusTime || '00:00:00'}

--- a/src/features/todo/AddTodo.tsx
+++ b/src/features/todo/AddTodo.tsx
@@ -27,7 +27,7 @@ export default function AddTodo({ selectedDate, onAdd }: AddTodoProps) {
       {isNotToday ? (
         <ReadOnlyMessage selectedDate={selectedDate} />
       ) : (
-        <form className="flex items-center gap-2 p-2" onSubmit={handleSubmit}>
+        <form className="flex items-center gap-2" onSubmit={handleSubmit}>
           <Input
             value={text}
             onChange={(e) => setText(e.target.value)}


### PR DESCRIPTION
## 📌 Description
Improved visual consistency across the layout by normalizing padding values in the mini dashboard and aligning the addTodo input with the overall page layout.

## 🛠️ Key Changes  
- Adjusted Mini Dashboard Padding: Unified inconsistent padding values to improve visual balance and layout consistency.  
- Refined addTodo Layout Spacing: Updated padding and spacing to better align with the global page layout and design system.

## 🧠 Design Notes  
- Focused purely on UI polish without introducing structural or logical changes.  
- Followed existing layout conventions to maintain consistency across pages.

## 📸ScreenShots
`before`
<img width="754" height="549" alt="before" src="https://github.com/user-attachments/assets/125ef6e7-dbe8-4686-be5a-2f6840838bde" />

`after`
<img width="774" height="490" alt="after" src="https://github.com/user-attachments/assets/f37c5730-1ab8-432f-a19a-0faec6bf1de0" />

## ✅ Checklist  
- [x] Padding values are consistent across related components  
- [x] No layout-breaking changes introduced  
- [x] No business logic or structure was modified  
