### PR TITLE
Fix: separate view date from selected date to restore correct active state

### DIFF
--- a/src/features/date/WeeklyCalendar.tsx
+++ b/src/features/date/WeeklyCalendar.tsx
@@ -6,12 +6,16 @@ import TodayClock from './TodayClock';
 
 interface WeeklyCalendarProps {
   selectedDate: string;
-  onDateSelect: (date: string) => void;
+  viewDate: string;
+  onChangeViewDate: (date: string) => void;
+  onSelectDate: (date: string) => void;
 }
 
 export default function WeeklyCalendar({
   selectedDate,
-  onDateSelect,
+  viewDate,
+  onChangeViewDate,
+  onSelectDate,
 }: WeeklyCalendarProps) {
   const {
     baseDate,
@@ -20,16 +24,20 @@ export default function WeeklyCalendar({
     getPrevWeekDate,
     getNextWeekDate,
   } = useWeekNavigation({
-    currentDate: selectedDate || dayjs(),
+    currentDate: viewDate,
     allowFuture: true,
   });
 
-  const goToday = () => onDateSelect(getTodayDate());
-  const goPrevWeek = () => onDateSelect(getPrevWeekDate());
+  const goToday = () => {
+    const today = getTodayDate();
+    onChangeViewDate(today);
+    onSelectDate(today);
+  };
+  const goPrevWeek = () => onChangeViewDate(getPrevWeekDate());
   const goNextWeek = () => {
     const next = getNextWeekDate();
     if (!next) return;
-    onDateSelect(next);
+    onChangeViewDate(next);
   };
 
   const daysInWeek = Array.from({ length: 7 }, (_, i) => {
@@ -75,7 +83,7 @@ export default function WeeklyCalendar({
             <Button
               className={`text-lg sm:text-xl transition-all ${day.isSelected ? 'p-3 sm:p-4 text-xl sm:text-2xl' : 'text-gray-600'}`}
               variant={day.isSelected ? 'default' : 'ghost'}
-              onClick={() => onDateSelect(day.fullDate)}
+              onClick={() => onSelectDate(day.fullDate)}
             >
               {day.dateNumber}
             </Button>

--- a/src/pages/FocusHistoryPage.tsx
+++ b/src/pages/FocusHistoryPage.tsx
@@ -5,14 +5,10 @@ import FocusTimeBarChart from '@/features/history/FocusTimeBarChart';
 import FocusTrendChart from '@/features/history/FocusTrendChart';
 import useWeekNavigation from '@/hooks/useWeekNavigation';
 import { getDayStats } from '@/lib/utils';
-import {
-  useSelectedDate,
-  useSetSelectedDate,
-  useTodo,
-} from '@/stores/useTodoStore';
+import { useSelectedDate, useTodo } from '@/stores/useTodoStore';
 import type { Todo } from '@/types/types';
 import dayjs from 'dayjs';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import FocusHistoryLoading from '@/components/skeleton/FocusHistoryLoading';
 import ErrorState from '@/components/common/ErrorState';
@@ -20,7 +16,8 @@ import ErrorState from '@/components/common/ErrorState';
 export default function FocusHistoryPage() {
   const historyTodos = useTodo();
   const selectedDate = useSelectedDate();
-  const setSelectedDate = useSetSelectedDate();
+
+  const [historyBaseDate, setHistoryBaseDate] = useState(selectedDate);
 
   const { isLoading, isError } = useQuery({
     queryKey: ['focusHistory'],
@@ -32,7 +29,7 @@ export default function FocusHistoryPage() {
   });
 
   const { baseDate, currentMonth, getPrevWeekDate, getNextWeekDate } =
-    useWeekNavigation({ currentDate: selectedDate, allowFuture: false });
+    useWeekNavigation({ currentDate: historyBaseDate, allowFuture: false });
 
   const todosByDate = useMemo(
     () => groupTodosByDate(historyTodos),
@@ -59,11 +56,11 @@ export default function FocusHistoryPage() {
     });
   }, [chartData, baseDate]);
 
-  const goPrevWeek = () => setSelectedDate(getPrevWeekDate());
+  const goPrevWeek = () => setHistoryBaseDate(getPrevWeekDate());
   const goNextWeek = () => {
     const next = getNextWeekDate();
     if (!next) return;
-    setSelectedDate(next);
+    setHistoryBaseDate(next);
   };
 
   const nextWeekDate = getNextWeekDate();

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   useSelectedDate,
   useSetSelectedDate,
@@ -22,6 +23,8 @@ export default function TodayPage() {
   const todos = useTodo();
   const selectedDate = useSelectedDate();
   const setSelectedDate = useSetSelectedDate();
+
+  const [viewDate, setViewDate] = useState(selectedDate);
 
   const isPast = dayjs(selectedDate).isBefore(dayjs(), 'day');
   const isFuture = dayjs(selectedDate).isAfter(dayjs(), 'day');
@@ -54,7 +57,9 @@ export default function TodayPage() {
     <div className="flex flex-col gap-4">
       <WeeklyCalendar
         selectedDate={selectedDate}
-        onDateSelect={setSelectedDate}
+        viewDate={viewDate}
+        onChangeViewDate={setViewDate}
+        onSelectDate={setSelectedDate}
       />
 
       {isLoading ? (


### PR DESCRIPTION
## 📌 Description
Refined the weekly calendar architecture by clearly separating **week navigation state** from the **explicitly selected date**.

This change restores the intended UI behavior where navigating between weeks does not implicitly activate a date, while still maintaining a single source of truth for the selected date.

---

## 🛠️ Key Changes
- **Separated View Date vs Selected Date**
  - Introduced a local `viewDate` to control week navigation without mutating the globally selected date.
  - Ensured that only explicit user actions (date clicks, Today button) update `selectedDate`.

- **Weekly Calendar Behavior Fix**
  - Prevented unintended active background states when navigating between weeks.
  - Restored correct visual feedback for the selected date only.

- **Maintained Hook Purity**
  - Kept `useWeekNavigation` as a pure, stateless date-derivation hook.
  - Centralized state ownership at the page level for clearer responsibility boundaries.

---

## 🧠 Design Notes
- **Explicit UX Modeling**
  - Navigating a calendar week and selecting a specific date represent different user intents and therefore require separate state handling.
- **Progressive Architecture Refinement**
  - This PR revisits a previous refactor decision after validating real UI behavior, reflecting an iterative and requirement-driven design process.

---

## 📝 PR Retrospective
Initially, week navigation and date selection were unified under a single state for simplicity.
However, real UI interactions revealed that this coupling caused unintended active states.
This PR reintroduces a lightweight view-level state to better align the implementation with user intent and visual expectations.

---
## 📸 ScreenShots
<img width="749" height="651" alt="1" src="https://github.com/user-attachments/assets/dbda8939-b2ca-4b9c-8af5-ff34ec58a65a" />
<img width="730" height="574" alt="2" src="https://github.com/user-attachments/assets/5e68ab37-b4a6-45e6-8570-2b2cdafeccdc" />

---

## ✅ Checklist
- [x] Week navigation no longer mutates selected date implicitly
- [x] Selected date is highlighted only when explicitly chosen
- [x] No internal state added back to `useWeekNavigation`