### PR TITLE
fix(ui): prevent empty state from rendering on read-only dates

### DIFF
--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -82,7 +82,7 @@ export default function TodayPage() {
 
       {isLoading ? (
         <TodoItemSkeleton />
-      ) : todosData.length === 0 ? (
+      ) : !readOnlyVariant && todosData.length === 0 ? (
         <EmptyTodo />
       ) : (
         <TodoList filteredTodos={todosData} />


### PR DESCRIPTION
## 📌 Description
- Fixed an issue where the empty state message ("No tasks for today") was rendered on past or future dates.
 On read-only dates, users cannot add or edit tasks, but the empty state UI was still displayed, causing conflicting UX signals.
- This PR ensures the empty state is shown **only for editable (today) dates**.
Fixes #29 
---

## 🛠️ Key Changes
- **Conditional Rendering Fix**  
  - Updated empty state rendering logic to check `readOnlyVariant`
  - Empty state is now displayed only when:
    - The selected date is editable (today)
    - The todo list is actually empty

```tsx
!readOnlyVariant && todosData.length === 0
```
- **UX Consistency Improvement**
   - Prevented confusing UI where users were prompted to add tasks on dates that are not editable
---
## 🧠 Design Notes
- **Single Source of Truth**
    - readOnlyVariant is treated as the authoritative indicator for whether user actions are allowed
- **UI-State Alignment**
    - Ensured that UI feedback (empty state CTA) matches actual user capabilities
- **Defensive UI Design**
    - Avoided misleading affordances on past/future dates
---
## 📸ScreenShots
`before`
<img width="727" height="580" alt="before" src="https://github.com/user-attachments/assets/7239dd1c-2704-4a09-853e-b9d07b3f3fe6" />

`after`
<img width="738" height="542" alt="after" src="https://github.com/user-attachments/assets/e9d5b817-6792-4008-8e73-cf0bc36439ab" />
<img width="764" height="547" alt="a1" src="https://github.com/user-attachments/assets/10938882-78d0-4667-8a17-2e819befb6dd" />
<img width="746" height="677" alt="a2" src="https://github.com/user-attachments/assets/579b83ae-5ec7-4d1f-b506-a0a4414196f2" />

---
## ✅ Checklist
- [x] Code follows project conventions
- [x] Self-reviewed the code
- [x] Verified behavior on past / today / future dates
