### PR TITLE
Feat: stabilize todo cache strategy and split date-based hooks

### DIFF
--- a/src/components/modal/HistoryDetailModal.tsx
+++ b/src/components/modal/HistoryDetailModal.tsx
@@ -4,7 +4,7 @@ import useDayDashboard from '@/hooks/useDayDashboard';
 import { DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
 import { DialogDescription } from '@radix-ui/react-dialog';
 import { useSession } from '@/stores/session';
-import { useTodo } from '@/hooks/queries/useTodo';
+import { useHistoryTodos } from '@/hooks/queries/useHistoryTodos';
 
 interface HistoryDetailModalProps {
   date: string;
@@ -12,7 +12,7 @@ interface HistoryDetailModalProps {
 
 export default function HistoryDetailModal({ date }: HistoryDetailModalProps) {
   const session = useSession();
-  const { data: todos = [] } = useTodo(date!, session?.user.id);
+  const { data: todos = [] } = useHistoryTodos(date!, session?.user.id);
 
   const {
     todosData,

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -3,7 +3,10 @@ export const todoKeys = {
 
   allTodos: (userId: string) => [...todoKeys.all, 'all', userId] as const,
 
-  byDate: (date: string) => [...todoKeys.all, 'date', date] as const,
+  dateRoot: () => [...todoKeys.all, 'date'] as const,
 
-  detail: (id: string) => [...todoKeys.all, 'detail', id] as const,
+  byDate: (date: string, userId: string) =>
+    [...todoKeys.all, 'date', date, userId] as const,
+
+  byId: (id: string) => [...todoKeys.all, 'item', id] as const,
 };

--- a/src/hooks/mutations/todo/useCreateTodo.ts
+++ b/src/hooks/mutations/todo/useCreateTodo.ts
@@ -1,18 +1,22 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createTodo } from '@/api/todo';
 import type { UseMutationCallback } from '@/types/types';
-import { useSelectedDate } from '@/stores/useTodoStore';
 import { todoKeys } from '@/constants/queryKeys';
+import { useSession } from '@/stores/session';
 
 export function useCreateTodo(callbacks?: UseMutationCallback) {
   const queryClient = useQueryClient();
-  const selectedDate = useSelectedDate();
+  const session = useSession();
+  const userId = session?.user.id;
 
   return useMutation({
     mutationFn: createTodo,
-    onSuccess: async () => {
-      const queryKey = todoKeys.byDate(selectedDate);
-      await queryClient.invalidateQueries({ queryKey });
+    onSuccess: async (_, variables) => {
+      if (!userId) return;
+
+      await queryClient.invalidateQueries({
+        queryKey: todoKeys.byDate(variables.date, userId),
+      });
       if (callbacks?.onSuccess) callbacks.onSuccess();
     },
     onError: (error) => {

--- a/src/hooks/mutations/todo/useDeleteTodo.ts
+++ b/src/hooks/mutations/todo/useDeleteTodo.ts
@@ -1,21 +1,65 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteTodo } from '@/api/todo';
-import type { UseMutationCallback } from '@/types/types';
-import { useSelectedDate } from '@/stores/useTodoStore';
+import type { TodoEntity, UseMutationCallback } from '@/types/types';
 import { todoKeys } from '@/constants/queryKeys';
+import { useSession } from '@/stores/session';
 
 export function useDeleteTodo(callbacks?: UseMutationCallback) {
   const queryClient = useQueryClient();
-  const selectedDate = useSelectedDate();
+  const session = useSession();
+  const userId = session?.user.id;
 
   return useMutation({
     mutationFn: (id: string) => deleteTodo(id),
-    onSuccess: async () => {
-      const queryKey = todoKeys.byDate(selectedDate);
-      await queryClient.invalidateQueries({ queryKey });
+
+    onMutate: async (id: string) => {
+      if (!userId) return;
+
+      await queryClient.cancelQueries({
+        queryKey: todoKeys.all,
+      });
+
+      const queries = queryClient.getQueriesData<TodoEntity[]>({
+        queryKey: todoKeys.dateRoot(),
+      });
+
+      const previousDates = queries.map(([key, data]) => ({
+        key,
+        data,
+      }));
+
+      queries.forEach(([key, old]) => {
+        queryClient.setQueryData(
+          key,
+          old?.filter((todo) => todo.id !== id),
+        );
+      });
+
+      const itemKey = todoKeys.byId(id);
+      const previousItem = queryClient.getQueryData(itemKey);
+
+      queryClient.removeQueries({ queryKey: itemKey });
+
+      return { previousDates, previousItem, itemKey };
+    },
+
+    onSettled: async () => {
+      if (!userId) return;
+
+      await queryClient.invalidateQueries({
+        queryKey: todoKeys.all,
+      });
       if (callbacks?.onSuccess) callbacks.onSuccess();
     },
-    onError: (error) => {
+
+    onError: (error, _, context) => {
+      context?.previousDates?.forEach(({ key, data }) => {
+        queryClient.setQueryData(key, data);
+      });
+
+      if (context?.previousItem) {
+        queryClient.setQueryData(context.itemKey, context.previousItem);
+      }
       if (callbacks?.onError) callbacks.onError(error);
     },
   });

--- a/src/hooks/mutations/todo/useUpdateTodo.ts
+++ b/src/hooks/mutations/todo/useUpdateTodo.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateTodo } from '@/api/todo';
 import type { TodoEntity, UseMutationCallback } from '@/types/types';
 import { todoKeys } from '@/constants/queryKeys';
-import { useSelectedDate } from '@/stores/useTodoStore';
+import { useSession } from '@/stores/session';
 
 type UpdateTodoVariables = {
   id: string;
@@ -12,36 +12,57 @@ type UpdateTodoVariables = {
 
 export function useUpdateTodo(callbacks?: UseMutationCallback) {
   const queryClient = useQueryClient();
-  const selectedDate = useSelectedDate();
+  const session = useSession();
+  const userId = session?.user.id;
 
   return useMutation({
     mutationFn: ({ id, updates }: UpdateTodoVariables) =>
       updateTodo(id, updates),
 
     onSuccess: async () => {
-      const queryKey = todoKeys.byDate(selectedDate);
-      await queryClient.invalidateQueries({ queryKey });
+      await queryClient.invalidateQueries({
+        queryKey: todoKeys.all,
+      });
       if (callbacks?.onSuccess) callbacks.onSuccess();
     },
 
     onMutate: async ({ id, updates, date }) => {
-      const queryKey = todoKeys.byDate(date);
-      await queryClient.cancelQueries({ queryKey });
+      if (!userId) return;
 
-      const previousTodos = queryClient.getQueryData<TodoEntity[]>(queryKey);
+      await queryClient.cancelQueries({
+        queryKey: todoKeys.all,
+      });
+
+      const dateKey = todoKeys.byDate(date, userId);
+      const itemKey = todoKeys.byId(id);
+
+      const previousTodos = queryClient.getQueryData<TodoEntity[]>(dateKey);
+
+      const previousItem = queryClient.getQueryData<TodoEntity>(itemKey);
 
       queryClient.setQueryData<TodoEntity[]>(
-        queryKey,
+        dateKey,
         (old) =>
           old?.map((todo) =>
             todo.id === id ? { ...todo, ...updates } : todo,
           ) ?? [],
       );
 
-      return { previousTodos, queryKey };
+      queryClient.setQueryData<TodoEntity>(itemKey, (old) =>
+        old ? { ...old, ...updates } : old,
+      );
+
+      return { previousTodos, previousItem, dateKey, itemKey };
     },
 
-    onError: (error) => {
+    onError: (error, _, context) => {
+      if (context?.previousTodos) {
+        queryClient.setQueryData(context.dateKey, context.previousTodos);
+      }
+
+      if (context?.previousItem) {
+        queryClient.setQueryData(context.itemKey, context.previousItem);
+      }
       if (callbacks?.onError) callbacks.onError(error);
     },
   });

--- a/src/hooks/queries/useAllTodos.ts
+++ b/src/hooks/queries/useAllTodos.ts
@@ -7,5 +7,6 @@ export function useAllTodos(userId?: string) {
     queryKey: userId ? todoKeys.allTodos(userId) : [],
     queryFn: () => getAllTodos(userId!),
     enabled: !!userId,
+    staleTime: 1000 * 60 * 10,
   });
 }

--- a/src/hooks/queries/useHistoryTodos.ts
+++ b/src/hooks/queries/useHistoryTodos.ts
@@ -2,9 +2,9 @@ import { getTodosByDate } from '@/api/todo';
 import { todoKeys } from '@/constants/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
-export function useTodo(date: string, userId: string | undefined) {
+export function useHistoryTodos(date: string, userId: string | undefined) {
   return useQuery({
-    queryKey: todoKeys.byDate(date),
+    queryKey: userId ? todoKeys.byDate(date, userId) : [],
     queryFn: () => getTodosByDate(date, userId!),
     enabled: !!userId,
     staleTime: 1000 * 60 * 5,

--- a/src/hooks/queries/useTodayTodos.ts
+++ b/src/hooks/queries/useTodayTodos.ts
@@ -1,0 +1,16 @@
+import { getTodosByDate } from '@/api/todo';
+import { todoKeys } from '@/constants/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+
+export function useTodayTodos(date: string, userId: string | undefined) {
+  const isToday = dayjs(date).isSame(dayjs(), 'day');
+
+  return useQuery({
+    queryKey: userId ? todoKeys.byDate(date, userId) : [],
+    queryFn: () => getTodosByDate(date, userId!),
+    enabled: !!userId,
+    staleTime: isToday ? 1000 * 60 * 3 : Infinity,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/hooks/queries/useTodoById.ts
+++ b/src/hooks/queries/useTodoById.ts
@@ -4,8 +4,10 @@ import { useQuery } from '@tanstack/react-query';
 
 export function useTodoById(id?: string) {
   return useQuery({
-    queryKey: id ? todoKeys.detail(id) : [],
+    queryKey: id ? todoKeys.byId(id) : [],
     queryFn: () => getTodoById(id!),
     enabled: !!id,
+    staleTime: 1000 * 60 * 3,
+    refetchOnWindowFocus: false,
   });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -62,7 +62,7 @@ createRoot(document.getElementById('root')!).render(
         <RouterProvider router={router} />
         <Toaster richColors position="top-center" />
       </SessionProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -12,7 +12,7 @@ import ReadOnlyMessage from '@/components/common/ReadOnlyMessage';
 import EmptyTodo from '@/components/common/EmptyTodo';
 import ErrorState from '@/components/common/ErrorState';
 import dayjs from 'dayjs';
-import { useTodo } from '@/hooks/queries/useTodo';
+import { useTodayTodos } from '@/hooks/queries/useTodayTodos';
 
 type ReadOnlyVariant = 'past' | 'future';
 
@@ -27,7 +27,7 @@ export default function TodayPage() {
     data: todosData = [],
     isLoading,
     isError,
-  } = useTodo(selectedDate, session?.user.id);
+  } = useTodayTodos(selectedDate, session?.user.id);
 
   const { formattedFocusTime, completionRate, completedCount, totalCount } =
     useDayDashboard({ todos: todosData, targetDate: selectedDate });


### PR DESCRIPTION
## 📌 Description

Refactored todo query architecture to improve cache consistency, optimistic update reliability, and date-based query separation.

This PR stabilizes the React Query cache strategy and separates concerns between today and historical queries.

---

## 🛠️ Key Changes

* **QueryKey Refactor**:

  * Added `dateRoot` for prefix-based cache control
  * Renamed `detail` to `byId`
  * Unified item key prefix

* **Hook Separation**:

  * Split `useTodo` into `useTodayTodos` and `useHistoryTodos`
  * Updated TodayPage and HistoryDetailModal to use the new hooks

* **Cache Strategy Improvements**:

  * Added `staleTime` to `useAllTodos`
  * Updated `useTodoById` with:

    * `staleTime: 3 minutes`
    * `refetchOnWindowFocus: false`
    * updated queryKey structure

* **Mutation Stabilization**:

  * Refactored `useCreateTodo`, `useUpdateTodo`, and `useDeleteTodo`
  * Unified optimistic update pattern
  * Standardized invalidate strategy

---

## 🧠 Design Notes

* Historical dates are treated as immutable, allowing longer `staleTime`.
* Today queries use a shorter freshness window.
* Prefix-based invalidation (`todoKeys.all`) ensures consistent synchronization.
* Optimistic updates are paired with rollback safety for mutation stability.
* Devtools remain development-only.

---

## ✅ Checklist

* [x] QueryKey structure unified
* [x] Date-based hooks separated
* [x] Mutation optimistic update stabilized
* [x] Cache invalidation strategy unified
* [x] Development-only Devtools preserved

