### PR TITLE
Feat/focus-session-domain-separation

### DIFF
--- a/src/api/focus.ts
+++ b/src/api/focus.ts
@@ -1,0 +1,25 @@
+import supabase from '@/lib/supabase';
+import type { FocusInsert } from '@/types/types';
+
+export async function createFocusSession(session: FocusInsert) {
+  const { data, error } = await supabase
+    .from('focus_sessions')
+    .insert(session)
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export async function getFocusSessionsByDate(userId: string, date: string) {
+  const { data, error } = await supabase
+    .from('focus_sessions')
+    .select('*')
+    .eq('user_id', userId)
+    .gte('start_time', `${date}T00:00:00`)
+    .lt('start_time', `${date}T23:59:59`)
+    .order('start_time', { ascending: false });
+
+  if (error) throw error;
+  return data;
+}

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -10,3 +10,10 @@ export const todoKeys = {
 
   byId: (id: string) => [...todoKeys.all, 'item', id] as const,
 };
+
+export const focusKeys = {
+  all: (userId: string) => ['focus', userId] as const,
+
+  byDate: (userId: string, date: string) =>
+    [...focusKeys.all(userId), 'date', date] as const,
+};

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -14,6 +14,44 @@ export type Database = {
   }
   public: {
     Tables: {
+      focus_sessions: {
+        Row: {
+          created_at: string | null
+          duration: number
+          end_time: string
+          id: string
+          start_time: string
+          todo_id: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          duration: number
+          end_time: string
+          id?: string
+          start_time: string
+          todo_id?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          duration?: number
+          end_time?: string
+          id?: string
+          start_time?: string
+          todo_id?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fk_focus_todo"
+            columns: ["todo_id"]
+            isOneToOne: false
+            referencedRelation: "todo"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       todo: {
         Row: {
           created_at: string

--- a/src/hooks/mutations/focus/useCreateFocusSession.ts
+++ b/src/hooks/mutations/focus/useCreateFocusSession.ts
@@ -1,0 +1,31 @@
+import { createFocusSession } from '@/api/focus';
+import { focusKeys } from '@/constants/queryKeys';
+import { useSession } from '@/stores/session';
+import type { UseMutationCallback } from '@/types/types';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useCreateFocusSession(callbacks?: UseMutationCallback) {
+  const queryClient = useQueryClient();
+  const session = useSession();
+  const userId = session?.user.id;
+
+  return useMutation({
+    mutationFn: createFocusSession,
+
+    onSuccess: async (newSession) => {
+      if (!userId) return;
+
+      const dateKey = newSession.start_time.split('T')[0];
+
+      await queryClient.invalidateQueries({
+        queryKey: focusKeys.byDate(userId, dateKey),
+      });
+
+      callbacks?.onSuccess?.();
+    },
+
+    onError: (error: any) => {
+      callbacks?.onError?.(error);
+    },
+  });
+}

--- a/src/hooks/queries/useFocusSessionsByDate.ts
+++ b/src/hooks/queries/useFocusSessionsByDate.ts
@@ -1,0 +1,16 @@
+import { getFocusSessionsByDate } from '@/api/focus';
+import { focusKeys } from '@/constants/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+
+export function useFocusSessionsByDate(date: string, userId?: string) {
+  const isToday = dayjs(date).isSame(dayjs(), 'day');
+
+  return useQuery({
+    queryKey: userId ? focusKeys.byDate(userId, date) : [],
+    queryFn: () => getFocusSessionsByDate(userId!, date),
+    enabled: !!userId,
+    staleTime: isToday ? 1000 * 60 * 3 : Infinity,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -2,25 +2,29 @@ import CustomDurationModal from '@/components/modal/CustomDurationModal';
 import { FocusStopModal } from '@/components/modal/FocusStopModal';
 import TimerCompletionModal from '@/components/modal/TimerCompletionModal';
 import { Button } from '@/components/ui/button';
+import { useCreateFocusSession } from '@/hooks/mutations/focus/useCreateFocusSession';
 import { useUpdateTodo } from '@/hooks/mutations/todo/useUpdateTodo';
 import { useTodoById } from '@/hooks/queries/useTodoById';
 import useTimer from '@/hooks/useTimer';
 import { formatTime } from '@/lib/utils';
+import { useSession } from '@/stores/session';
 import { useSelectedDate } from '@/stores/useTodoStore';
-import type { Todo } from '@/types/types';
 import { MoveLeft, Pause, Play, Square } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
 export default function FocusPage() {
   const selectedDate = useSelectedDate();
+  const session = useSession();
 
   const navigate = useNavigate();
   const { todoId } = useParams<{ todoId: string }>();
 
   const { data: currentTodo } = useTodoById(todoId);
-
   const { mutate: updateTodo } = useUpdateTodo();
+  const { mutate: createFocusSession } = useCreateFocusSession({
+    onSuccess: () => navigate('/'),
+  });
 
   const [isStopModalOpen, setIsStopModalOpen] = useState(false);
   const [isCompletionModalOpen, setIsCompletionModalOpen] = useState(false);
@@ -53,28 +57,38 @@ export default function FocusPage() {
   };
 
   const handleSaveAndExit = () => {
-    if (!todoId || !currentTodo) return;
+    if (!todoId || !currentTodo || !session?.user.id) return;
 
     const focusedSeconds = initialTime - timeLeft;
 
     if (focusedSeconds > 0) {
+      const now = new Date();
+      const startTime = new Date(now.getTime() - focusedSeconds * 1000);
+
       const newTotal = (currentTodo.total_focus_time ?? 0) + focusedSeconds;
-
-      const updates: Partial<Todo> = {
-        total_focus_time: newTotal,
-      };
-
-      if (timeLeft === 0 && currentTodo.status !== 'completed') {
-        updates.status = 'completed';
-      }
 
       updateTodo({
         id: todoId,
-        updates,
+        updates: {
+          total_focus_time: newTotal,
+          ...(timeLeft === 0 &&
+            currentTodo.status !== 'completed' && {
+              status: 'completed',
+            }),
+        },
         date: selectedDate,
       });
+
+      createFocusSession({
+        user_id: session.user.id,
+        todo_id: todoId,
+        start_time: startTime.toISOString(),
+        end_time: now.toISOString(),
+        duration: focusedSeconds,
+      });
+    } else {
+      navigate('/');
     }
-    navigate('/');
   };
 
   if (!currentTodo) return <div>No todo items found</div>;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,6 +3,10 @@ import type { Database } from '@/database.types';
 export type TodoEntity = Database['public']['Tables']['todo']['Row'];
 export type TodoInsert = Database['public']['Tables']['todo']['Insert'];
 
+export type FocusEntity = Database['public']['Tables']['focus_sessions']['Row'];
+export type FocusInsert =
+  Database['public']['Tables']['focus_sessions']['Insert'];
+
 export type TodoStatus = 'active' | 'completed';
 
 export interface Todo extends TodoEntity {}


### PR DESCRIPTION
## 📌 Description

This PR separates the Focus Session domain and implements a dedicated service layer, React Query hooks, and type-safe
integration with Supabase.

The goal was to decouple focus session logic from the UI and establish a scalable domain structure.

---

## 🛠️ Key Changes

- **Supabase Types Integration**: Imported generated database types for type safety
- **Focus Types Definition**: Flattened and separated `Row` and `Insert` types
- **Service Layer Implementation**: Added `createFocusSession` and `getFocusSessionsByDate`
- **React Query Keys**: Defined structured query keys for focus domain
- **Custom Hooks**: Implemented `useCreateFocusSession` and `useFocusSessionsByDate`
- **UI Integration**: Connected focus session creation to `FocusPage`

---

## 🧠 Design Notes

- **Type Safety**: Used Supabase `Insert` type to prevent invalid mutation payloads
- **Domain Separation**: Focus logic is now isolated from presentation layer
- **Cache Strategy**: Query keys are structured by date and user for precise invalidation
- **Data Integrity**: FK is configured with `ON DELETE SET NULL` to preserve focus history

---

## ✅ Checklist

- [x] Supabase types integrated
- [x] Focus domain types separated
- [x] Service layer implemented
- [x] React Query hooks added
- [x] UI integration completed
- [x] Local testing passed