### PR TITLE
Feat: migrate focus statistics to session-based aggregation

### DIFF
--- a/src/api/focus.ts
+++ b/src/api/focus.ts
@@ -1,5 +1,6 @@
 import supabase from '@/lib/supabase';
 import type { FocusInsert } from '@/types/types';
+import dayjs from 'dayjs';
 
 export async function createFocusSession(session: FocusInsert) {
   const { data, error } = await supabase
@@ -22,4 +23,70 @@ export async function getFocusSessionsByDate(userId: string, date: string) {
 
   if (error) throw error;
   return data;
+}
+
+export async function getTotalFocusTime(userId: string) {
+  const { data, error } = await supabase
+    .from('focus_sessions')
+    .select('duration')
+    .eq('user_id', userId);
+
+  if (error) throw error;
+
+  const total = data?.reduce((acc, curr) => acc + curr.duration, 0) ?? 0;
+  return total;
+}
+
+export async function getTodayFocusTime(userId: string, date: string) {
+  const start = dayjs(date).startOf('day').toDate();
+  const end = dayjs(date).add(1, 'day').startOf('day').toDate();
+
+  const { data, error } = await supabase
+    .from('focus_sessions')
+    .select('duration')
+    .eq('user_id', userId)
+    .gte('start_time', start.toISOString())
+    .lt('start_time', end.toISOString());
+
+  if (error) throw error;
+  return data?.reduce((sum, row) => sum + row.duration, 0) ?? 0;
+}
+
+export async function getTodoFocusTime(todoId: string) {
+  const { data, error } = await supabase
+    .from('focus_sessions')
+    .select('duration')
+    .eq('todo_id', todoId);
+
+  if (error) throw error;
+
+  const total = data?.reduce((acc, curr) => acc + curr.duration, 0) ?? 0;
+  return total;
+}
+
+export async function getDailyAggregation(
+  userId: string,
+  from: string,
+  to: string,
+) {
+  const start = dayjs(from).startOf('day').toISOString();
+  const end = dayjs(to).add(1, 'day').startOf('day').toISOString();
+
+  const { data, error } = await supabase
+    .from('focus_sessions')
+    .select('start_time, duration')
+    .eq('user_id', userId)
+    .gte('start_time', start)
+    .lt('start_time', end);
+
+  if (error) throw error;
+
+  const map: Record<string, number> = {};
+
+  data?.forEach((session) => {
+    const date = dayjs(session.start_time).format('YYYY-MM-DD');
+    map[date] = (map[date] || 0) + session.duration;
+  });
+
+  return map;
 }

--- a/src/components/modal/HistoryDetailModal.tsx
+++ b/src/components/modal/HistoryDetailModal.tsx
@@ -5,6 +5,7 @@ import { DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
 import { DialogDescription } from '@radix-ui/react-dialog';
 import { useSession } from '@/stores/session';
 import { useHistoryTodos } from '@/hooks/queries/useHistoryTodos';
+import useTodayFocusTime from '@/hooks/queries/focus/useTodayFocusTime';
 
 interface HistoryDetailModalProps {
   date: string;
@@ -12,15 +13,13 @@ interface HistoryDetailModalProps {
 
 export default function HistoryDetailModal({ date }: HistoryDetailModalProps) {
   const session = useSession();
-  const { data: todos = [] } = useHistoryTodos(date!, session?.user.id);
+  const userId = session?.user.id;
 
-  const {
-    todosData,
-    formattedFocusTime,
-    completionRate,
-    completedCount,
-    totalCount,
-  } = useDayDashboard({ todos, targetDate: date! });
+  const { data: todos = [] } = useHistoryTodos(date!, userId);
+  const { data: focusSeconds = 0 } = useTodayFocusTime(userId ?? '', date);
+
+  const { formattedFocusTime, completionRate, completedCount, totalCount } =
+    useDayDashboard({ todos, totalFocusSeconds: focusSeconds });
 
   return (
     <DialogContent className="max-w-[90vw] md:max-w-2xl w-full max-h-[85vh] overflow-y-auto border-2 rounded-4xl p-4 sm:p-8 ">
@@ -43,8 +42,8 @@ export default function HistoryDetailModal({ date }: HistoryDetailModalProps) {
       </div>
 
       <ul className="space-y-4">
-        {todosData.map((todo) => (
-          <HistoryTodoRow key={todo.id} todo={todo} date={date} />
+        {todos.map((todo) => (
+          <HistoryTodoRow key={todo.id} todo={todo} />
         ))}
       </ul>
     </DialogContent>

--- a/src/components/modal/TimerCompletionModal.tsx
+++ b/src/components/modal/TimerCompletionModal.tsx
@@ -11,13 +11,13 @@ import { Button } from '../ui/button';
 interface TimerCompletionModalProps {
   open: boolean;
   onConfirm: () => void;
-  total_focus_time: string;
+  totalFocusDisplay: string;
 }
 
 export default function TimerCompletionModal({
   open,
   onConfirm,
-  total_focus_time: total_focus_time,
+  totalFocusDisplay,
 }: TimerCompletionModalProps) {
   return (
     <Dialog open={open}>
@@ -27,7 +27,7 @@ export default function TimerCompletionModal({
             Focus Complete!⭐️
           </DialogTitle>
           <DialogDescription className="text-center pt-4 text-lg">
-            You’ve completed **{total_focus_time}** of deep work. Ready to save
+            You’ve completed **{totalFocusDisplay}** of deep work. Ready to save
             and head back?
           </DialogDescription>
         </DialogHeader>

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -12,8 +12,18 @@ export const todoKeys = {
 };
 
 export const focusKeys = {
-  all: (userId: string) => ['focus', userId] as const,
+  root: ['focus'] as const,
+
+  all: (userId: string) => [...focusKeys.root, userId] as const,
+
+  daily: (userId: string, from: string, to: string) =>
+    [...focusKeys.all(userId), 'daily', from, to] as const,
 
   byDate: (userId: string, date: string) =>
     [...focusKeys.all(userId), 'date', date] as const,
+
+  total: (userId: string) => [...focusKeys.all(userId), 'total'] as const,
+
+  todo: (userId: string, todoId: string) =>
+    [...focusKeys.all(userId), 'todo', todoId] as const,
 };

--- a/src/features/history/DayHistoryCard.tsx
+++ b/src/features/history/DayHistoryCard.tsx
@@ -1,18 +1,17 @@
 import HistoryDetailModal from '@/components/modal/HistoryDetailModal';
 import { Dialog, DialogTrigger } from '@/components/ui/dialog';
-import { formatTime, getDayStats } from '@/lib/utils';
-import type { Todo } from '@/types/types';
+import { formatTime } from '@/lib/utils';
+import type { HistoryStat } from '@/types/types';
 import { CircleCheck, Clock4 } from 'lucide-react';
 
 interface DayHistoryCardProps {
   date: string;
-  dayTodos: Todo[];
-  stats: ReturnType<typeof getDayStats>;
+  stats: HistoryStat;
 }
 
 export default function DayHistoryCard({
   date,
-  dayTodos,
+
   stats,
 }: DayHistoryCardProps) {
   return (
@@ -22,7 +21,7 @@ export default function DayHistoryCard({
           <header className="flex justify-between items-center text-lg">
             <div className="flex items-baseline gap-1.5">
               <span className="text-xl font-bold font-mono">{date}</span>
-              <span className="text-sm text-muted-foreground font-medium">{`(${stats.completedCount}/${dayTodos.length})`}</span>
+              <span className="text-sm text-muted-foreground font-medium">{`(${stats.completedCount}/${stats.totalCount})`}</span>
             </div>
             <div className="flex items-center gap-6 font-mono font-semibold">
               <div className="flex items-center gap-1.5 ">
@@ -31,7 +30,7 @@ export default function DayHistoryCard({
               </div>
               <div className="flex items-center gap-1.5">
                 <Clock4 className="w-4 h-4" />
-                {formatTime(stats.totalFocusSeconds).fullTimeDisplay}
+                {formatTime(stats.totalSeconds).fullTimeDisplay}
               </div>
             </div>
           </header>

--- a/src/features/history/HistoryTodoRow.tsx
+++ b/src/features/history/HistoryTodoRow.tsx
@@ -14,13 +14,17 @@ import TodoTextEditor from '@/components/common/TodoTextEditor';
 import AlertModal from '@/components/modal/AlertModal';
 import { useDeleteTodo } from '@/hooks/mutations/todo/useDeleteTodo';
 import { useUpdateTodo } from '@/hooks/mutations/todo/useUpdateTodo';
+import useTodoFocusTime from '@/hooks/queries/focus/useTodoFocusTime';
+import { useSession } from '@/stores/session';
 
 interface HistoryTodoRowProps {
   todo: Todo;
-  date: string;
 }
 
-export default function HistoryTodoRow({ todo, date }: HistoryTodoRowProps) {
+export default function HistoryTodoRow({ todo }: HistoryTodoRowProps) {
+  const session = useSession();
+  const userId = session?.user.id;
+
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const { mutate: deleteTodo } = useDeleteTodo();
@@ -35,7 +39,8 @@ export default function HistoryTodoRow({ todo, date }: HistoryTodoRowProps) {
     handleKeyDown,
   } = useTodoEdit({ todo, onUpdate: updateTodo });
 
-  const { id, status, total_focus_time } = todo;
+  const { id, status } = todo;
+  const { data: focusTime = 0 } = useTodoFocusTime(userId, todo.id);
 
   return (
     <li key={id} className="flex justify-between items-center px-5 py-2">
@@ -51,7 +56,7 @@ export default function HistoryTodoRow({ todo, date }: HistoryTodoRowProps) {
 
         {!isEditing && (
           <span className="ml-3 font-mono text-sm">
-            {formatTime(total_focus_time || 0).fullTimeDisplay}
+            {formatTime(focusTime).fullTimeDisplay}
           </span>
         )}
       </div>

--- a/src/features/todo/TodoItems.tsx
+++ b/src/features/todo/TodoItems.tsx
@@ -8,6 +8,8 @@ import { useNavigate } from 'react-router';
 import AlertModal from '@/components/modal/AlertModal';
 import TodoTextEditor from '@/components/common/TodoTextEditor';
 import useTodoEdit from '@/hooks/useTodoEdit';
+import useTodoFocusTime from '@/hooks/queries/focus/useTodoFocusTime';
+import { useSession } from '@/stores/session';
 
 interface TodoItemProps {
   todo: Todo;
@@ -20,9 +22,12 @@ interface TodoItemProps {
 }
 
 export default function TodoItems({ todo, onDelete, onUpdate }: TodoItemProps) {
+  const session = useSession();
+  const userId = session?.user.id;
   const navigate = useNavigate();
 
-  const { id, status, total_focus_time, date } = todo;
+  const { id, status, date } = todo;
+  const { data: focusSeconds = 0 } = useTodoFocusTime(userId, id);
 
   const isReadOnly = !isToday(date);
 
@@ -103,9 +108,7 @@ export default function TodoItems({ todo, onDelete, onUpdate }: TodoItemProps) {
         </div>
       </div>
       <div className="flex justify-end items-center w-full">
-        <div className="mr-5">
-          {formatTime(total_focus_time || 0).fullTimeDisplay}
-        </div>
+        <div className="mr-5">{formatTime(focusSeconds).fullTimeDisplay}</div>
         <Button
           onClick={() => navigate(`/focus/${id}`)}
           disabled={todo.status === 'completed' || isReadOnly}

--- a/src/hooks/mutations/focus/useCreateFocusSession.ts
+++ b/src/hooks/mutations/focus/useCreateFocusSession.ts
@@ -12,13 +12,11 @@ export function useCreateFocusSession(callbacks?: UseMutationCallback) {
   return useMutation({
     mutationFn: createFocusSession,
 
-    onSuccess: async (newSession) => {
+    onSuccess: async () => {
       if (!userId) return;
 
-      const dateKey = newSession.start_time.split('T')[0];
-
       await queryClient.invalidateQueries({
-        queryKey: focusKeys.byDate(userId, dateKey),
+        queryKey: focusKeys.root,
       });
 
       callbacks?.onSuccess?.();

--- a/src/hooks/queries/focus/useDailyAggregation.ts
+++ b/src/hooks/queries/focus/useDailyAggregation.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { getDailyAggregation } from '@/api/focus';
+import { focusKeys } from '@/constants/queryKeys';
+
+export interface DailyAggregation {
+  date: string;
+  totalSeconds: number;
+}
+
+export const useDailyAggregation = (
+  userId?: string,
+  from?: string,
+  to?: string,
+) => {
+  return useQuery({
+    queryKey: userId && from && to ? focusKeys.daily(userId, from, to) : [],
+
+    queryFn: async (): Promise<DailyAggregation[]> => {
+      if (!userId || !from || !to) return [];
+
+      const data = await getDailyAggregation(userId, from, to);
+
+      return Object.entries(data).map(([date, totalSeconds]) => ({
+        date,
+        totalSeconds,
+      }));
+    },
+
+    enabled: !!userId && !!from && !!to,
+  });
+};

--- a/src/hooks/queries/focus/useTodayFocusTime.ts
+++ b/src/hooks/queries/focus/useTodayFocusTime.ts
@@ -1,0 +1,11 @@
+import { getTodayFocusTime } from '@/api/focus';
+import { focusKeys } from '@/constants/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+
+export default function useTodayFocusTime(userId?: string, date?: string) {
+  return useQuery({
+    queryKey: userId && date ? focusKeys.byDate(userId, date) : [],
+    queryFn: () => getTodayFocusTime(userId!, date!),
+    enabled: !!userId && !!date,
+  });
+}

--- a/src/hooks/queries/focus/useTodoFocusTime.ts
+++ b/src/hooks/queries/focus/useTodoFocusTime.ts
@@ -1,0 +1,11 @@
+import { getTodoFocusTime } from '@/api/focus';
+import { focusKeys } from '@/constants/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+
+export default function useTodoFocusTime(userId?: string, todoId?: string) {
+  return useQuery({
+    queryKey: userId && todoId ? focusKeys.todo(userId, todoId) : [],
+    queryFn: () => getTodoFocusTime(todoId!),
+    enabled: !!userId && !!todoId,
+  });
+}

--- a/src/hooks/queries/focus/useTotalFocusTime.ts
+++ b/src/hooks/queries/focus/useTotalFocusTime.ts
@@ -1,0 +1,12 @@
+import { getTotalFocusTime } from '@/api/focus';
+import { focusKeys } from '@/constants/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+
+export default function useTotalFocusTime(userId?: string) {
+  return useQuery({
+    queryKey: userId ? focusKeys.total(userId) : [],
+    queryFn: () => getTotalFocusTime(userId!),
+    enabled: !!userId,
+    staleTime: 1000 * 60,
+  });
+}

--- a/src/hooks/useDayDashboard.ts
+++ b/src/hooks/useDayDashboard.ts
@@ -1,32 +1,31 @@
-import { formatTime, getDayStats } from '@/lib/utils';
+import { formatTime } from '@/lib/utils';
 import type { Todo } from '@/types/types';
 import { useMemo } from 'react';
 
 interface UseDayDashboardProps {
   todos: Todo[];
-  targetDate: string;
+  totalFocusSeconds: number;
 }
 
 export default function useDayDashboard({
   todos,
-  targetDate,
+  totalFocusSeconds,
 }: UseDayDashboardProps) {
-  const todosData = useMemo(
-    () => todos.filter((todo) => todo.date === targetDate),
-    [todos, targetDate],
-  );
+  const totalCount = todos.length;
 
-  const stats = useMemo(() => getDayStats(todosData), [todosData]);
-  const formattedFocusTime = useMemo(
-    () => formatTime(stats.totalFocusSeconds).fullTimeDisplay,
-    [stats.totalFocusSeconds],
-  );
+  const completedCount = todos.filter(
+    (todo) => todo.status === 'completed',
+  ).length;
+
+  const completionRate =
+    totalCount > 0 ? Math.floor((completedCount / totalCount) * 100) : 0;
+
+  const formattedFocusTime = formatTime(totalFocusSeconds).fullTimeDisplay;
 
   return {
-    todosData,
+    totalCount,
+    completionRate,
+    completedCount,
     formattedFocusTime,
-    completionRate: stats.completionRate,
-    completedCount: stats.completedCount || 0,
-    totalCount: stats.totalCount,
   };
 }

--- a/src/hooks/useHistoryDashboard.ts
+++ b/src/hooks/useHistoryDashboard.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
+import type { HistoryStat, Todo } from '@/types/types';
+
+interface DailyFocus {
+  date: string;
+  totalSeconds: number;
+}
+
+export function useHistoryDashboard(todos: Todo[], focusData: DailyFocus[]) {
+  return useMemo<HistoryStat[]>(() => {
+    const todoMap = new Map<string, { total: number; completed: number }>();
+
+    for (const todo of todos) {
+      const date = todo.date;
+
+      if (!todoMap.has(date)) {
+        todoMap.set(date, { total: 0, completed: 0 });
+      }
+
+      const entry = todoMap.get(date)!;
+      entry.total += 1;
+      if (todo.status === 'completed') {
+        entry.completed += 1;
+      }
+    }
+
+    const result: HistoryStat[] = [];
+
+    const allDates = new Set([
+      ...focusData.map((f) => f.date),
+      ...todoMap.keys(),
+    ]);
+
+    for (const date of allDates) {
+      const todoEntry = todoMap.get(date);
+      const focusEntry = focusData.find((f) => f.date === date);
+
+      const totalCount = todoEntry?.total ?? 0;
+      const completedCount = todoEntry?.completed ?? 0;
+
+      result.push({
+        date,
+        totalSeconds: focusEntry?.totalSeconds ?? 0,
+        totalCount,
+        completedCount,
+        completionRate:
+          totalCount > 0 ? Math.floor((completedCount / totalCount) * 100) : 0,
+      });
+    }
+
+    return result.sort((a, b) =>
+      dayjs(a.date).isAfter(dayjs(b.date)) ? 1 : -1,
+    );
+  }, [todos, focusData]);
+}

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -1,38 +1,30 @@
 import dayjs from 'dayjs';
-import { getDayStats } from '@/lib/utils';
-import type { ChartData, Todo } from '@/types/types';
-
-type TodosByDateMap = Record<string, Todo[]>;
+import type { ChartData, HistoryStat } from '@/types/types';
 
 export default function prepareChartData(
-  todosByDate: TodosByDateMap,
+  historyStats: HistoryStat[],
 ): ChartData[] {
-  const existingEntries = Object.entries(todosByDate)
-    .map(([dateStr, todos]) => ({
-      dateStr,
-      stats: getDayStats(todos),
-    }))
-    .sort((a, b) => (dayjs(a.dateStr).isAfter(dayjs(b.dateStr)) ? 1 : -1));
+  if (historyStats.length === 0) return [];
 
-  if (existingEntries.length === 0) return [];
+  const sorted = [...historyStats].sort((a, b) =>
+    dayjs(a.date).isAfter(dayjs(b.date)) ? 1 : -1,
+  );
 
-  const firstDate = dayjs(existingEntries[0].dateStr);
-  const lastDate = dayjs(existingEntries[existingEntries.length - 1].dateStr);
+  const firstDate = dayjs(sorted[0].date);
+  const lastDate = dayjs(sorted[sorted.length - 1].date);
 
   const filledData: ChartData[] = [];
   let runner = firstDate;
 
   while (runner.isBefore(lastDate) || runner.isSame(lastDate, 'day')) {
     const currentFormatted = runner.format('YYYY-MM-DD');
-    const foundEntry = existingEntries.find(
-      (e) => e.dateStr === currentFormatted,
-    );
+    const foundEntry = sorted.find((e) => e.date === currentFormatted);
 
     if (foundEntry) {
       filledData.push({
         date: runner.toDate(),
-        completionRate: foundEntry.stats.completionRate,
-        totalMinutes: Math.floor(foundEntry.stats.totalFocusSeconds / 60),
+        completionRate: foundEntry.completionRate,
+        totalMinutes: Math.floor(foundEntry.totalSeconds / 60),
       });
     } else {
       filledData.push({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,31 +21,6 @@ export const formatTime = (totalSeconds: number) => {
   return { fullTimeDisplay, hours, minutes, seconds };
 };
 
-export const getDayStats = (dayTodos: Todo[]) => {
-  const totalCount = dayTodos.length;
-
-  const totalFocusSeconds = dayTodos.reduce(
-    (acc, todo) => acc + (todo.total_focus_time || 0),
-    0,
-  );
-
-  const completedCount = dayTodos.filter(
-    (todo) => todo.status === 'completed',
-  ).length;
-
-  const completionRate =
-    dayTodos.length > 0
-      ? Math.floor((completedCount / dayTodos.length) * 100)
-      : 0;
-
-  return {
-    totalCount,
-    totalFocusSeconds,
-    completionRate,
-    completedCount,
-  };
-};
-
 export const isToday = (date: string | Date | number): boolean => {
   return dayjs(date).isSame(dayjs(), 'day');
 };

--- a/src/pages/FocusHistoryPage.tsx
+++ b/src/pages/FocusHistoryPage.tsx
@@ -4,7 +4,6 @@ import DateNavigationHeader from '@/components/common/DateNavigationHeader';
 import FocusTimeBarChart from '@/features/history/FocusTimeBarChart';
 import FocusTrendChart from '@/features/history/FocusTrendChart';
 import useWeekNavigation from '@/hooks/useWeekNavigation';
-import { getDayStats } from '@/lib/utils';
 import { useSelectedDate } from '@/stores/useTodoStore';
 import type { Todo } from '@/types/types';
 import dayjs from 'dayjs';
@@ -13,6 +12,8 @@ import FocusHistoryLoading from '@/components/skeleton/FocusHistoryLoading';
 import ErrorState from '@/components/common/ErrorState';
 import { useSession } from '@/stores/session';
 import { useAllTodos } from '@/hooks/queries/useAllTodos';
+import { useDailyAggregation } from '@/hooks/queries/focus/useDailyAggregation';
+import { useHistoryDashboard } from '@/hooks/useHistoryDashboard';
 
 export default function FocusHistoryPage() {
   const session = useSession();
@@ -20,22 +21,31 @@ export default function FocusHistoryPage() {
   const [historyBaseDate, setHistoryBaseDate] = useState(selectedDate);
 
   const userId = session?.user.id;
-  const { data: historyTodos = [], isLoading, isError } = useAllTodos(userId);
 
   const { baseDate, currentMonth, getPrevWeekDate, getNextWeekDate } =
     useWeekNavigation({ currentDate: historyBaseDate, allowFuture: false });
 
-  const todosByDate = useMemo(
-    () => groupTodosByDate(historyTodos),
-    [historyTodos],
-  );
+  const from = baseDate.startOf('week').format('YYYY-MM-DD');
+  const to = baseDate.endOf('week').format('YYYY-MM-DD');
 
-  const sortedDates = useMemo(
-    () => Object.keys(todosByDate).sort((a, b) => b.localeCompare(a)),
-    [todosByDate],
-  );
+  const {
+    data: historyTodos = [],
+    isLoading: todosLoading,
+    isError: todosError,
+  } = useAllTodos(userId);
 
-  const chartData = useMemo(() => prepareChartData(todosByDate), [todosByDate]);
+  const {
+    data: dailyFocus = [],
+    isLoading: focusLoading,
+    isError: focusError,
+  } = useDailyAggregation(userId, from, to);
+
+  const historyStats = useHistoryDashboard(historyTodos, dailyFocus);
+
+  const chartData = useMemo(
+    () => prepareChartData(historyStats),
+    [historyStats],
+  );
 
   const weeklyData = useMemo(() => {
     const start = baseDate.startOf('day');
@@ -60,8 +70,10 @@ export default function FocusHistoryPage() {
   const nextWeekDate = getNextWeekDate();
   const isNextDisabled = !nextWeekDate;
 
-  if (isLoading) return <FocusHistoryLoading />;
-  if (isError) return <ErrorState message="Failed to load today's data." />;
+  if (todosLoading || focusLoading) return <FocusHistoryLoading />;
+
+  if (todosError || focusError)
+    return <ErrorState message="Failed to load history data." />;
 
   return (
     <div className="flex flex-col gap-3">
@@ -81,22 +93,9 @@ export default function FocusHistoryPage() {
         </div>
       </div>
 
-      {sortedDates.map((date) => (
-        <DayHistoryCard
-          key={date}
-          date={date}
-          dayTodos={todosByDate[date]}
-          stats={getDayStats(todosByDate[date])}
-        />
+      {historyStats.map((stat) => (
+        <DayHistoryCard key={stat.date} date={stat.date} stats={stat} />
       ))}
     </div>
   );
 }
-
-const groupTodosByDate = (todos: Todo[]): Record<string, Todo[]> =>
-  todos.reduce<Record<string, Todo[]>>((acc, todo) => {
-    const dateKey = todo.date;
-    if (!acc[dateKey]) acc[dateKey] = [];
-    acc[dateKey].push(todo);
-    return acc;
-  }, {});

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -4,6 +4,7 @@ import TimerCompletionModal from '@/components/modal/TimerCompletionModal';
 import { Button } from '@/components/ui/button';
 import { useCreateFocusSession } from '@/hooks/mutations/focus/useCreateFocusSession';
 import { useUpdateTodo } from '@/hooks/mutations/todo/useUpdateTodo';
+import useTodoFocusTime from '@/hooks/queries/focus/useTodoFocusTime';
 import { useTodoById } from '@/hooks/queries/useTodoById';
 import useTimer from '@/hooks/useTimer';
 import { formatTime } from '@/lib/utils';
@@ -16,11 +17,14 @@ import { useNavigate, useParams } from 'react-router';
 export default function FocusPage() {
   const selectedDate = useSelectedDate();
   const session = useSession();
+  const userId = session?.user.id;
 
   const navigate = useNavigate();
   const { todoId } = useParams<{ todoId: string }>();
 
   const { data: currentTodo } = useTodoById(todoId);
+  const { data: totalFocus = 0 } = useTodoFocusTime(userId, todoId);
+
   const { mutate: updateTodo } = useUpdateTodo();
   const { mutate: createFocusSession } = useCreateFocusSession({
     onSuccess: () => navigate('/'),
@@ -43,11 +47,7 @@ export default function FocusPage() {
   } = useTimer({
     initialSeconds: 1500,
     onComplete: (elapsedSeconds) => {
-      if (!currentTodo) return;
-
-      const total = (currentTodo.total_focus_time ?? 0) + elapsedSeconds;
-
-      setPreviewTotal(total);
+      setPreviewTotal(elapsedSeconds);
       setIsCompletionModalOpen(true);
     },
   });
@@ -68,30 +68,15 @@ export default function FocusPage() {
   const handleSaveAndExit = () => {
     if (!todoId || !currentTodo || !session?.user.id) return;
 
-    const previousTotal = currentTodo.total_focus_time ?? 0;
-    const focusedSeconds = previewTotal - previousTotal;
+    const focusedSeconds = previewTotal;
 
     if (focusedSeconds <= 0) {
       navigate('/');
       return;
     }
 
-    setIsCompletionModalOpen(false);
-
     const now = new Date();
     const startTime = new Date(now.getTime() - focusedSeconds * 1000);
-
-    updateTodo({
-      id: todoId,
-      updates: {
-        total_focus_time: previewTotal,
-        ...(timeLeft === 0 &&
-          currentTodo.status !== 'completed' && {
-            status: 'completed',
-          }),
-      },
-      date: selectedDate,
-    });
 
     createFocusSession({
       user_id: session.user.id,
@@ -100,6 +85,14 @@ export default function FocusPage() {
       end_time: now.toISOString(),
       duration: focusedSeconds,
     });
+
+    if (timeLeft === 0 && currentTodo?.status !== 'completed') {
+      updateTodo({
+        id: todoId,
+        updates: { status: 'completed' },
+        date: selectedDate,
+      });
+    }
   };
 
   if (!currentTodo) return <div>No todo items found</div>;
@@ -173,7 +166,7 @@ export default function FocusPage() {
 
         <div className="flex gap-3">
           <div className="text-muted-foreground">Total Focus Time</div>
-          <div>{formatTime(currentTodo.total_focus_time).fullTimeDisplay}</div>
+          <div>{formatTime(totalFocus).fullTimeDisplay}</div>
         </div>
       </footer>
 
@@ -192,7 +185,7 @@ export default function FocusPage() {
       <TimerCompletionModal
         open={isCompletionModalOpen}
         onConfirm={handleSaveAndExit}
-        total_focus_time={formatTime(previewTotal).fullTimeDisplay}
+        totalFocusDisplay={formatTime(previewTotal).fullTimeDisplay}
       />
     </div>
   );

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -13,6 +13,7 @@ import EmptyTodo from '@/components/common/EmptyTodo';
 import ErrorState from '@/components/common/ErrorState';
 import dayjs from 'dayjs';
 import { useTodayTodos } from '@/hooks/queries/useTodayTodos';
+import useTodayFocusTime from '@/hooks/queries/focus/useTodayFocusTime';
 
 type ReadOnlyVariant = 'past' | 'future';
 
@@ -29,8 +30,16 @@ export default function TodayPage() {
     isError,
   } = useTodayTodos(selectedDate, session?.user.id);
 
+  const { data: totalFocusSeconds = 0 } = useTodayFocusTime(
+    session?.user.id ?? '',
+    selectedDate,
+  );
+
   const { formattedFocusTime, completionRate, completedCount, totalCount } =
-    useDayDashboard({ todos: todosData, targetDate: selectedDate });
+    useDayDashboard({
+      todos: todosData,
+      totalFocusSeconds,
+    });
 
   const isPast = dayjs(selectedDate).isBefore(dayjs(), 'day');
   const isFuture = dayjs(selectedDate).isAfter(dayjs(), 'day');

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -23,3 +23,11 @@ export type UseMutationCallback = {
   onMutate?: () => void;
   onSettled?: () => void;
 };
+
+export interface HistoryStat {
+  date: string;
+  totalSeconds: number;
+  totalCount: number;
+  completedCount: number;
+  completionRate: number;
+}


### PR DESCRIPTION
## 📌 Description

Refactor focus time calculation to use focus session aggregation instead of relying on denormalized todo fields.

This change introduces aggregation APIs and React Query hooks to compute focus statistics from the focus_sessions table, making it the single source of truth for focus time data.

---

## 🛠️ Key Changes

* **Aggregation APIs**

  * Added `getTotalFocusTime`
  * Added `getTodayFocusTime`
  * Added `getTodoFocusTime`
  * Added `getDailyAggregation`

* **React Query Hooks**

  * Added `useTotalFocusTime`
  * Added `useTodayFocusTime`
  * Added `useTodoFocusTime`
  * Added `useDailyAggregation`

* **Dashboard Refactor**

  * Updated `useDayDashboard`
  * Removed legacy `getDayStats`
  * Removed `groupTodosByDate`

* **Focus History Refactor**

  * FocusHistoryPage now uses aggregated stats
  * Chart utilities updated

* **Timer Logic Update**

  * Fixed preview focus calculation
  * Simplified elapsed time logic

---

## 🧠 Design Notes

Previously, focus time was stored in todos.total_focus_time, which created a risk of data inconsistency (dual writes).

This refactor shifts focus statistics to be derived from the focus_sessions table, making it the single source of truth.

Benefits:
- Eliminates potential dual write inconsistencies
- Simplifies statistics computation
- Enables more flexible analytics (daily, todo-level, total)

---

## ✅ Checklist

- [x] Added aggregation APIs
- [x] Introduced React Query hooks for focus statistics
- [x] Refactored dashboard to use aggregated data
- [x] Removed legacy statistics utilities

