### PR TITLE
chore: enable Zustand devtools only in development

### DIFF
--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -40,6 +40,7 @@ const useSessionStore = create(
     })),
     {
       name: 'sessionStore',
+      enabled: import.meta.env.DEV,
     },
   ),
 );


### PR DESCRIPTION
## 📌 Description
Disable Zustand devtools in production to prevent exposing client state and reduce unnecessary overhead.

## 🛠️ Key Changes
- **Devtools control**: Enabled devtools only in development environment

## 🧠 Design Notes
- **Security consideration**: Avoid exposing internal state in production

## ✅ Checklist
- [x] Types verified
- [x] Local testing completed
- [x] Auth flow tested (login, logout, refresh)