### PR TITLE
fix/sync-todo-cache-with-optimistic-update

### DIFF
--- a/src/hooks/mutations/todo/useCreateTodo.ts
+++ b/src/hooks/mutations/todo/useCreateTodo.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createTodo } from '@/api/todo';
-import type { UseMutationCallback } from '@/types/types';
+import type { TodoEntity, UseMutationCallback } from '@/types/types';
 import { todoKeys } from '@/constants/queryKeys';
 import { useSession } from '@/stores/session';
 
@@ -11,16 +11,47 @@ export default function useCreateTodo(callbacks?: UseMutationCallback) {
 
   return useMutation({
     mutationFn: createTodo,
-    onSuccess: async (_, variables) => {
+
+    onMutate: async (newTodo) => {
       if (!userId) return;
 
-      await queryClient.invalidateQueries({
-        queryKey: todoKeys.byDate(variables.date, userId),
+      await queryClient.cancelQueries({
+        queryKey: todoKeys.allTodos(userId),
       });
-      if (callbacks?.onSuccess) callbacks.onSuccess();
+
+      const previous = queryClient.getQueryData<TodoEntity[]>(
+        todoKeys.allTodos(userId),
+      );
+
+      queryClient.setQueryData(
+        todoKeys.allTodos(userId),
+        (old: TodoEntity[] = []) => {
+          return [...old, newTodo];
+        },
+      );
+
+      return { previous };
     },
-    onError: (error) => {
-      if (callbacks?.onError) callbacks.onError(error);
+
+    onError: (_, __, context) => {
+      if (context?.previous && userId) {
+        queryClient.setQueryData(todoKeys.allTodos(userId), context.previous);
+      }
+    },
+
+    onSettled: async (_, __, variables) => {
+      if (!userId) return;
+
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: todoKeys.byDate(variables.date, userId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: todoKeys.allTodos(userId),
+        }),
+      ]);
+
+      callbacks?.onSuccess?.();
     },
   });
 }


### PR DESCRIPTION
## 📌 Description

Ensure consistent todo data across Today and History pages by introducing optimistic updates and fixing cache invalidation strategy.

Previously, newly created todos were immediately reflected on the Today page but not on the History page until a manual refresh. This was caused by missing synchronization between different React Query caches.

Fixes: #58 

---

## 🛠️ Key Changes
- **Optimistic Update (createTodo)**: Added `onMutate` to immediately update the `allTodos` cache when a new todo is created.
- **Cache Synchronization**: Updated invalidation logic to include both `byDate` and `allTodos` query keys.
- **Consistency Fix**: Ensured History page reflects newly created todos without requiring a refetch.

---

## 🧠 Design Notes
- **Server State Consistency**: Separated query keys (`byDate`, `allTodos`) require explicit synchronization to maintain consistent UI state.
- **Optimistic UI Strategy**:
Applied optimistic updates for create operations to improve UX and eliminate delay caused by refetching.
- **Query Key Precision**:
Replaced broad invalidation (`['todo']`) with targeted invalidation (`allTodos(userId)`) to ensure correct cache updates.

---

## ✅ Checklist
- [x] Code follows project conventions
- [x] Verified on local environment
- [x] History page updates immediately after todo creation
