### PR TITLE
Feat/dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,31 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FocusDo</title>
   </head>
+  <script>
+    try {
+      const themeStore = localStorage.getItem('ThemeStore')
+        ? JSON.parse(localStorage.getItem('ThemeStore'))
+        : null;
+
+      const theme = themeStore.state.theme;
+
+      const htmlTag = document.documentElement;
+      htmlTag.classList.remove('dark', 'light');
+
+      if (theme === 'system') {
+        const isDarkTheme = window.matchMedia(
+          '(prefers-color-scheme:dark)',
+        ).matches;
+
+        htmlTag.classList.add(isDarkTheme ? 'dark' : 'light');
+      } else {
+        htmlTag.classList.add(theme);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  </script>
+
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/src/components/header/Navbar.tsx
+++ b/src/components/header/Navbar.tsx
@@ -1,7 +1,8 @@
-import { AlarmClockCheck, Sun } from 'lucide-react';
+import { AlarmClockCheck } from 'lucide-react';
 import { Link } from 'react-router';
 import MenuButton from './MenuButton';
 import { useSession } from '@/stores/session';
+import ThemeBtn from './ThemeBtn';
 
 export default function Navbar() {
   const session = useSession();
@@ -15,7 +16,7 @@ export default function Navbar() {
         </div>
       </Link>
       <nav className="flex items-center gap-5">
-        <Sun className="w-5 h-5 sm:w-6 sm:h-6" />
+        <ThemeBtn />
         {session && <MenuButton />}
       </nav>
     </header>

--- a/src/components/header/ThemeBtn.tsx
+++ b/src/components/header/ThemeBtn.tsx
@@ -6,24 +6,12 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import type { Theme } from '@/types/types';
+import { useSetTheme } from '@/stores/themeStore';
 
 const THEMES: Theme[] = ['system', 'dark', 'light'];
 
 export default function ThemeBtn() {
-  const onChangeTheme = (theme: Theme) => {
-    const htmlTag = document.documentElement;
-    htmlTag.classList.remove('dark', 'light');
-
-    if (theme === 'system') {
-      const isDarkTheme = window.matchMedia(
-        '(prefers-color-scheme:dark)',
-      ).matches;
-
-      htmlTag.classList.add(isDarkTheme ? 'dark' : 'light');
-    } else {
-      htmlTag.classList.add(theme);
-    }
-  };
+  const setTheme = useSetTheme();
 
   return (
     <DropdownMenu>
@@ -35,7 +23,7 @@ export default function ThemeBtn() {
           <DropdownMenuItem key={`theme-button-${theme}`} asChild>
             <div
               className="hover:bg-muted cursor-pointer p-3"
-              onClick={() => onChangeTheme(theme)}
+              onClick={() => setTheme(theme)}
             >
               {theme}
             </div>

--- a/src/components/header/ThemeBtn.tsx
+++ b/src/components/header/ThemeBtn.tsx
@@ -1,4 +1,4 @@
-import { Sun } from 'lucide-react';
+import { CheckIcon, Sun } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -6,11 +6,12 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import type { Theme } from '@/types/types';
-import { useSetTheme } from '@/stores/themeStore';
+import { useSetTheme, useTheme } from '@/stores/themeStore';
 
 const THEMES: Theme[] = ['system', 'dark', 'light'];
 
 export default function ThemeBtn() {
+  const currentTheme = useTheme();
   const setTheme = useSetTheme();
 
   return (
@@ -22,10 +23,11 @@ export default function ThemeBtn() {
         {THEMES.map((theme) => (
           <DropdownMenuItem key={`theme-button-${theme}`} asChild>
             <div
-              className="hover:bg-muted cursor-pointer p-3"
+              className="hover:bg-muted flex cursor-pointer items-center justify-between p-3"
               onClick={() => setTheme(theme)}
             >
               {theme}
+              {currentTheme === theme && <CheckIcon className="h-4 w-4" />}
             </div>
           </DropdownMenuItem>
         ))}

--- a/src/components/header/ThemeBtn.tsx
+++ b/src/components/header/ThemeBtn.tsx
@@ -1,0 +1,47 @@
+import { Sun } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
+import type { Theme } from '@/types/types';
+
+const THEMES: Theme[] = ['system', 'dark', 'light'];
+
+export default function ThemeBtn() {
+  const onChangeTheme = (theme: Theme) => {
+    const htmlTag = document.documentElement;
+    htmlTag.classList.remove('dark', 'light');
+
+    if (theme === 'system') {
+      const isDarkTheme = window.matchMedia(
+        '(prefers-color-scheme:dark)',
+      ).matches;
+
+      htmlTag.classList.add(isDarkTheme ? 'dark' : 'light');
+    } else {
+      htmlTag.classList.add(theme);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="outline-none focus:ring-0 focus-visible:ring-0">
+        <Sun className="w-5 h-5 sm:w-6 sm:h-6" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-35 p-0">
+        {THEMES.map((theme) => (
+          <DropdownMenuItem key={`theme-button-${theme}`} asChild>
+            <div
+              className="hover:bg-muted cursor-pointer p-3"
+              onClick={() => onChangeTheme(theme)}
+            >
+              {theme}
+            </div>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,7 @@ import ResetPasswordPage from './pages/ResetPasswordPage.tsx';
 import GuestOnlyLayout from './components/layout/GuestOnlyLayout.tsx';
 import AuthGuardLayout from './components/layout/AuthGuardLayout.tsx';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { ThemeProvider } from 'next-themes';
 
 const queryClient = new QueryClient();
 
@@ -57,12 +58,14 @@ const router = createBrowserRouter([
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <SessionProvider>
-        <RouterProvider router={router} />
-        <Toaster richColors position="top-center" />
-      </SessionProvider>
-      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <SessionProvider>
+          <RouterProvider router={router} />
+          <Toaster richColors position="top-center" />
+        </SessionProvider>
+        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+      </QueryClientProvider>
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/src/provider/ThemeProvider.tsx
+++ b/src/provider/ThemeProvider.tsx
@@ -1,0 +1,26 @@
+import { useThemeStore } from '@/stores/themeStore';
+import { useEffect } from 'react';
+
+export default function ThemeProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const setTheme = useThemeStore((s) => s.setTheme);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
+
+    if (stored) {
+      setTheme(stored);
+    } else {
+      const prefersDark = window.matchMedia(
+        '(prefers-color-scheme: dark)',
+      ).matches;
+
+      setTheme(prefersDark ? 'dark' : 'light');
+    }
+  }, [setTheme]);
+
+  return <>{children}</>;
+}

--- a/src/provider/ThemeProvider.tsx
+++ b/src/provider/ThemeProvider.tsx
@@ -1,4 +1,5 @@
-import { useThemeStore } from '@/stores/themeStore';
+import type { Theme } from '@/types/types';
+import { useSetTheme } from '@/stores/themeStore';
 import { useEffect } from 'react';
 
 export default function ThemeProvider({
@@ -6,20 +7,11 @@ export default function ThemeProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const setTheme = useThemeStore((s) => s.setTheme);
+  const setTheme = useSetTheme();
 
   useEffect(() => {
-    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
-
-    if (stored) {
-      setTheme(stored);
-    } else {
-      const prefersDark = window.matchMedia(
-        '(prefers-color-scheme: dark)',
-      ).matches;
-
-      setTheme(prefersDark ? 'dark' : 'light');
-    }
+    const stored = localStorage.getItem('theme') as Theme | null;
+    setTheme(stored ?? 'system');
   }, [setTheme]);
 
   return <>{children}</>;

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,30 +1,34 @@
+import type { Theme } from '@/types/types';
 import { create } from 'zustand';
-
-type Theme = 'light' | 'dark';
 
 type ThemeStore = {
   theme: Theme;
   setTheme: (theme: Theme) => void;
-  toggleTheme: () => void;
 };
 
-export const useThemeStore = create<ThemeStore>((set) => ({
-  theme: 'light',
+const applyTheme = (theme: Theme) => {
+  const htmlTag = document.documentElement;
+  htmlTag.classList.remove('dark', 'light');
+
+  if (theme === 'system') {
+    const isDarkTheme = window.matchMedia(
+      '(prefers-color-scheme:dark)',
+    ).matches;
+
+    htmlTag.classList.add(isDarkTheme ? 'dark' : 'light');
+  } else {
+    htmlTag.classList.add(theme);
+  }
+};
+
+const useThemeStore = create<ThemeStore>((set) => ({
+  theme: 'system',
 
   setTheme: (theme) => {
     localStorage.setItem('theme', theme);
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-
+    applyTheme(theme);
     set({ theme });
   },
-
-  toggleTheme: () =>
-    set((state) => {
-      const nextTheme = state.theme === 'light' ? 'dark' : 'light';
-
-      localStorage.setItem('theme', nextTheme);
-      document.documentElement.classList.toggle('dark', nextTheme === 'dark');
-
-      return { theme: nextTheme };
-    }),
 }));
+
+export const useSetTheme = () => useThemeStore((store) => store.setTheme);

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,34 +1,49 @@
 import type { Theme } from '@/types/types';
 import { create } from 'zustand';
+import { combine, devtools, persist } from 'zustand/middleware';
 
-type ThemeStore = {
+type State = {
   theme: Theme;
-  setTheme: (theme: Theme) => void;
 };
 
-const applyTheme = (theme: Theme) => {
-  const htmlTag = document.documentElement;
-  htmlTag.classList.remove('dark', 'light');
-
-  if (theme === 'system') {
-    const isDarkTheme = window.matchMedia(
-      '(prefers-color-scheme:dark)',
-    ).matches;
-
-    htmlTag.classList.add(isDarkTheme ? 'dark' : 'light');
-  } else {
-    htmlTag.classList.add(theme);
-  }
+const initialState: State = {
+  theme: 'light',
 };
 
-const useThemeStore = create<ThemeStore>((set) => ({
-  theme: 'system',
+const useThemeStore = create(
+  devtools(
+    persist(
+      combine(initialState, (set) => ({
+        actions: {
+          setTheme: (theme: Theme) => {
+            const htmlTag = document.documentElement;
+            htmlTag.classList.remove('dark', 'light');
 
-  setTheme: (theme) => {
-    localStorage.setItem('theme', theme);
-    applyTheme(theme);
-    set({ theme });
-  },
-}));
+            if (theme === 'system') {
+              const isDarkTheme = window.matchMedia(
+                '(prefers-color-scheme:dark)',
+              ).matches;
 
-export const useSetTheme = () => useThemeStore((store) => store.setTheme);
+              htmlTag.classList.add(isDarkTheme ? 'dark' : 'light');
+            } else {
+              htmlTag.classList.add(theme);
+            }
+            set({ theme });
+          },
+        },
+      })),
+      {
+        name: 'ThemeStore',
+        partialize: (store) => ({
+          theme: store.theme,
+        }),
+      },
+    ),
+    { name: 'ThemeStore' },
+  ),
+);
+
+export const useTheme = () => useThemeStore((store) => store.theme);
+
+export const useSetTheme = () =>
+  useThemeStore((store) => store.actions.setTheme);

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+type Theme = 'light' | 'dark';
+
+type ThemeStore = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
+
+export const useThemeStore = create<ThemeStore>((set) => ({
+  theme: 'light',
+
+  setTheme: (theme) => {
+    localStorage.setItem('theme', theme);
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+
+    set({ theme });
+  },
+
+  toggleTheme: () =>
+    set((state) => {
+      const nextTheme = state.theme === 'light' ? 'dark' : 'light';
+
+      localStorage.setItem('theme', nextTheme);
+      document.documentElement.classList.toggle('dark', nextTheme === 'dark');
+
+      return { theme: nextTheme };
+    }),
+}));

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -36,3 +36,5 @@ export interface DailyAggregation {
   date: string;
   totalSeconds: number;
 }
+
+export type Theme = 'system' | 'dark' | 'light';


### PR DESCRIPTION
## 📌 Description

Implemented dark mode with a clean separation of concerns acrossThemeStore, ThemeProvider, and ThemeBtn.
The theme logic was progressively refactored from the UI layerinto the store to follow the Single Source of Truth principle.
Also fixed a flash of unstyled content issue on page refresh.

---
## 🛠️ Key Changes

- **ThemeStore**: Centralized all theme logic including DOM class toggling
  and localStorage persistence. Removed toggleTheme as it conflicted with
  the system theme option. Added useSetTheme hook. Later refactored to
  integrate devtools, persist, and combine. Added useTheme hook for
  reading current theme state.
- **ThemeProvider**: Simplified to handle only initial theme restoration
  from localStorage on app mount. Uses useSetTheme hook.
- **ThemeBtn**: Added active theme indicator with a check icon using
  useTheme hook. Applied flex items-center justify-between to align icon.
- **main.tsx**: Wrapped the app with ThemeProvider to ensure theme is
  restored before first render.
- **index.html**: Added inline script with try/catch to apply theme class
  before React renders, preventing flash of unstyled content on refresh.

---
## 🧠 Design Notes
- **Single Source of Truth**: All theme-related side effects (classList,
  localStorage) are handled exclusively in ThemeStore to prevent logic
  duplication.
- **Role separation**: ThemeProvider handles initialization, ThemeStore
  handles logic, ThemeBtn handles user interaction only.
- **FOUC prevention**: useEffect runs after render, so persist and
  ThemeProvider alone cannot prevent flash on refresh. The inline script
  in index.html reads from localStorage before React renders, which is
  the only reliable solution.

---
## 📸 ScreenShots

`before`
<img width="769" height="504" alt="before" src="https://github.com/user-attachments/assets/a56f8e1f-8358-429e-abd8-16ca20f0102e" />

`after`
<img width="745" height="504" alt="after1" src="https://github.com/user-attachments/assets/032bdf78-83fb-4b31-9081-1fe56cddbb37" />
<img width="733" height="536" alt="after2" src="https://github.com/user-attachments/assets/a37ae55d-24cd-402e-8d66-06c1b12cb448" />

---
## ✅ Checklist
- [x] Dark / Light / System theme switching works correctly
- [x] Selected theme persists after page refresh
- [x] Active theme is visually indicated with a check icon in ThemeBtn
manipulate DOM