### PR TITLE
feat: persist timer state across page refreshes using localStorage

### DIFF
--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,31 +1,102 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useInterval } from 'usehooks-ts';
 
 export type TimerStatus = 'idle' | 'running' | 'paused' | 'completed';
 
+const STORAGE_KEY = 'focus_timer_state';
+
+interface StoredTimerState {
+  todoId: string;
+  status: TimerStatus;
+  currentInitialTime: number;
+  pausedElapsedSeconds: number;
+  runningStartedAt: number | null;
+}
+
 interface UseTimerProps {
   initialSeconds: number;
+  todoId: string;
   onComplete: (elapsedSeconds: number) => void;
+}
+
+function loadStoredState(todoId: string): StoredTimerState | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: StoredTimerState = JSON.parse(raw);
+    if (parsed.todoId !== todoId) return null;
+    if (parsed.status === 'completed') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function saveState(state: StoredTimerState) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function clearState() {
+  localStorage.removeItem(STORAGE_KEY);
 }
 
 export default function useTimer({
   initialSeconds,
+  todoId,
   onComplete,
 }: UseTimerProps) {
-  const [status, setStatus] = useState<TimerStatus>('idle');
-  const [timeLeft, setTimeLeft] = useState(initialSeconds);
-  const [currentInitialTime, setCurrentInitialTime] = useState(initialSeconds);
-  const startTimeRef = useRef<number | null>(null);
-  const pausedElapsedRef = useRef(0);
+  const stored = useMemo(() => loadStoredState(todoId), [todoId]);
+
+  const [status, setStatus] = useState<TimerStatus>(stored?.status ?? 'idle');
+  const [currentInitialTime, setCurrentInitialTime] = useState(
+    stored?.currentInitialTime ?? initialSeconds,
+  );
+
+  const restoredElapsed = useMemo(() => {
+    if (!stored) return 0;
+    if (stored.status === 'running' && stored.runningStartedAt !== null) {
+      return (
+        stored.pausedElapsedSeconds +
+        Math.floor((Date.now() - stored.runningStartedAt) / 1000)
+      );
+    }
+    return stored.pausedElapsedSeconds;
+  }, [stored]);
+
+  const [timeLeft, setTimeLeft] = useState(() => {
+    if (!stored) return initialSeconds;
+    const remaining = stored.currentInitialTime - restoredElapsed;
+    return Math.max(remaining, 0);
+  });
+
+  const startTimeRef = useRef<number | null>(
+    stored?.status === 'running' ? Date.now() : null,
+  );
+  const pausedElapsedRef = useRef(
+    stored?.status === 'running'
+      ? restoredElapsed
+      : (stored?.pausedElapsedSeconds ?? 0),
+  );
+
+  const persistState = useCallback(() => {
+    const state: StoredTimerState = {
+      todoId,
+      status,
+      currentInitialTime,
+      pausedElapsedSeconds: pausedElapsedRef.current,
+      runningStartedAt: startTimeRef.current,
+    };
+    saveState(state);
+  }, [todoId, status, currentInitialTime]);
 
   const setDuration = (minutes: number) => {
     const seconds = minutes * 60;
     setStatus('idle');
     setTimeLeft(seconds);
     setCurrentInitialTime(seconds);
-
     startTimeRef.current = null;
     pausedElapsedRef.current = 0;
+    clearState();
   };
 
   const togglePlay = () =>
@@ -40,11 +111,12 @@ export default function useTimer({
 
     if (status === 'paused' && startTimeRef.current !== null) {
       const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
-
       pausedElapsedRef.current += elapsed;
       startTimeRef.current = null;
     }
-  }, [status]);
+
+    persistState();
+  }, [status, persistState]);
 
   useInterval(
     () => {
@@ -59,11 +131,13 @@ export default function useTimer({
       if (remaining <= 0) {
         setTimeLeft(0);
         setStatus('completed');
+        clearState();
         onComplete(totalElapsed);
         return;
       }
 
       setTimeLeft(remaining);
+      persistState();
     },
     status === 'running' ? 1000 : null,
   );

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -46,6 +46,7 @@ export default function FocusPage() {
     resume,
   } = useTimer({
     initialSeconds: 1500,
+    todoId: todoId ?? '',
     onComplete: (elapsedSeconds) => {
       setPreviewTotal(elapsedSeconds);
       setIsCompletionModalOpen(true);


### PR DESCRIPTION
## 📌 Description

Fixes timer state being lost on page refresh during a focus session.
Previously, refreshing the page would reset the timer to its initial state,
causing all elapsed focus time to be lost.

Fixes: #65 
---

## 🛠️ Key Changes

- **`useTimer` – localStorage persistence**: Saves timer status,
  elapsed time, initial duration, and session start timestamp on every
  status change and tick so the state survives a page refresh.

- **`useTimer` – refresh restoration**: On mount, reads stored state
  and recomputes elapsed time (including time passed while the tab was
  closed), restoring `timeLeft` and `pausedElapsedRef` accordingly.

- **`useTimer` – state scoping via `todoId`**: Accepts a new `todoId`
  prop and ignores stored state when it belongs to a different todo,
  preventing stale state from leaking across sessions.

- **`useTimer` – auto-cleanup**: Clears localStorage on timer
  completion or when `setDuration` is called, avoiding stale data.

- **`FocusPage`**: Passes `todoId` from route params into `useTimer`.

---

## 🧠 Design Notes

- **`sessionStorage` vs `localStorage`**: Chose `localStorage` so state
  survives full tab closes, not just refreshes. A focus session is
  long-running and users may accidentally close the tab.

- **Running-state restoration**: When the stored status is `running`,
  elapsed time is recalculated using `Date.now() - runningStartedAt`,
  so the timer stays accurate even if the page was closed for several
  minutes.

- **No `completed` state restoration**: Completed sessions are not
  restored to avoid re-triggering the completion modal on refresh.

---

## ✅ Checklist

- [x] Timer resumes correctly after refresh while running
- [x] Timer restores correctly after refresh while paused
- [x] TypeScript types updated (`UseTimerProps` includes `todoId`)
- [x] No breaking changes to `FocusPage` other than passing `todoId`